### PR TITLE
Ensure logging init is idempotent and tested

### DIFF
--- a/qliber/src/logging.rs
+++ b/qliber/src/logging.rs
@@ -1,5 +1,6 @@
 use std::sync::OnceLock;
 
+use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tracing::info;
@@ -7,7 +8,7 @@ use tracing_subscriber::{EnvFilter, fmt};
 
 use crate::Result;
 
-static SUBSCRIBER: OnceLock<()> = OnceLock::new();
+static SUBSCRIBER: OnceLock<std::result::Result<(), String>> = OnceLock::new();
 
 const SHERLOCK_PROMPT: &str = "[Continuous skepticism (Sherlock Protocol)] Could this change affect unexpected files/systems? | Any hidden dependencies or cascades? | What edge cases and failure modes are unhandled? | If stuck, work backward from the desired outcome.";
 
@@ -31,22 +32,25 @@ pub struct LogEvent<'a> {
 /// Calling this function multiple times is safe; only the first invocation installs the
 /// subscriber.
 pub fn init_logging() -> Result<()> {
-    if SUBSCRIBER.get().is_some() {
-        return Ok(());
+    let result = SUBSCRIBER.get_or_init(|| {
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+        fmt()
+            .with_env_filter(filter)
+            .json()
+            .with_current_span(false)
+            .with_span_list(false)
+            .with_timer(fmt::time::UtcTime::rfc_3339())
+            .with_target(false)
+            .try_init()
+            .map_err(|error| error.to_string())?;
+
+        Ok(())
+    });
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(message) => Err(anyhow!(message.clone())),
     }
-
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    fmt()
-        .with_env_filter(filter)
-        .json()
-        .with_current_span(false)
-        .with_span_list(false)
-        .with_timer(fmt::time::UtcTime::rfc_3339())
-        .with_target(false)
-        .init();
-
-    let _ = SUBSCRIBER.set(());
-    Ok(())
 }
 
 /// Emit a structured log event conforming to the canonical schema alongside the

--- a/qliber/task.md
+++ b/qliber/task.md
@@ -11,3 +11,4 @@
 - [x] Validate Rust metrics parity with Qlib risk analysis outputs (sum & product modes)
 - [x] Extend metrics API with accumulation modes, information ratio, and drawdown support
 - [x] Refresh documentation and regression tests to capture the expanded evaluation surface
+- [x] Harden logging initialization to be concurrency-safe and idempotent

--- a/qliber/tests/logging.rs
+++ b/qliber/tests/logging.rs
@@ -1,0 +1,7 @@
+use qliber::logging;
+
+#[test]
+fn logging_initialization_is_idempotent() {
+    logging::init_logging().expect("first initialization succeeds");
+    logging::init_logging().expect("subsequent initialization succeeds");
+}


### PR DESCRIPTION
## Summary
- guard the tracing subscriber installation with a OnceLock result to prevent racy initialization
- surface initialization failures as anyhow errors instead of panicking and record the completed task
- add a regression test that asserts logging::init_logging can be called repeatedly

## Testing
- cargo fmt
- cargo clippy -- -D warnings
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68df38002cd4832b853d49af473e20ea