### PR TITLE
Align metrics API with Python parity

### DIFF
--- a/qliber/src/lib.rs
+++ b/qliber/src/lib.rs
@@ -9,6 +9,9 @@ pub mod metrics;
 
 pub use dataset::{DatasetError, MarketData};
 pub use features::{with_daily_returns, with_moving_average, with_z_score};
-pub use metrics::{AccumulationMode, PerformanceMetrics};
+pub use metrics::{
+    AccumulationMode, AnalysisFrequency, FrequencyUnit, IndicatorMethod, MetricsError,
+    MetricsResult, PerformanceMetrics, indicator_analysis,
+};
 
 pub type Result<T> = anyhow::Result<T>;

--- a/qliber/task.md
+++ b/qliber/task.md
@@ -12,3 +12,6 @@
 - [x] Extend metrics API with accumulation modes, information ratio, and drawdown support
 - [x] Refresh documentation and regression tests to capture the expanded evaluation surface
 - [x] Harden logging initialization to be concurrency-safe and idempotent
+- [x] Align Rust risk analysis API with Python frequency handling and return semantics
+- [x] Port indicator analysis weighting logic to Rust metrics module
+- [x] Expand regression tests and docs to cover the newly ported evaluation features

--- a/qliber/tests/pipeline.rs
+++ b/qliber/tests/pipeline.rs
@@ -4,10 +4,15 @@ use approx::assert_abs_diff_eq;
 use chrono::{TimeZone, Utc};
 use tempfile::NamedTempFile;
 
+use polars::prelude::*;
+
 use qliber::dataset::MarketData;
 use qliber::features::{with_daily_returns, with_moving_average, with_z_score};
 use qliber::logging;
-use qliber::metrics::{AccumulationMode, PerformanceMetrics};
+use qliber::metrics::{
+    AccumulationMode, AnalysisFrequency, FrequencyUnit, IndicatorMethod, PerformanceMetrics,
+    indicator_analysis,
+};
 
 #[test]
 fn end_to_end_pipeline_produces_expected_statistics() -> anyhow::Result<()> {
@@ -125,4 +130,78 @@ fn performance_metrics_align_with_python_risk_analysis() {
         product_mode.information_ratio,
         epsilon = 1e-12
     );
+}
+
+#[test]
+fn performance_metrics_frequency_parity() {
+    let returns = vec![0.01, -0.015, 0.02, -0.005];
+    let frequency = AnalysisFrequency::new(1, FrequencyUnit::Day);
+    let from_frequency =
+        PerformanceMetrics::evaluate_with_frequency(&returns, frequency, AccumulationMode::Sum);
+    let direct = PerformanceMetrics::evaluate_with_mode(&returns, 238.0, AccumulationMode::Sum);
+
+    assert_abs_diff_eq!(
+        from_frequency.annualized_return,
+        direct.annualized_return,
+        epsilon = 1e-12
+    );
+    assert_abs_diff_eq!(
+        from_frequency.information_ratio,
+        direct.information_ratio,
+        epsilon = 1e-12
+    );
+
+    let from_str =
+        PerformanceMetrics::evaluate_with_frequency_str(&returns, "2week", AccumulationMode::Sum)
+            .expect("valid frequency string");
+    let manual = PerformanceMetrics::evaluate_with_mode(&returns, 25.0, AccumulationMode::Sum);
+    assert_abs_diff_eq!(
+        from_str.annualized_return,
+        manual.annualized_return,
+        epsilon = 1e-12
+    );
+}
+
+#[test]
+fn indicator_analysis_matches_python_behaviour() -> anyhow::Result<()> {
+    let frame = df! {
+        "count" => &[5.0, 10.0, 20.0],
+        "ffr" => &[0.1, 0.5, 0.9],
+        "pa" => &[0.2, 0.8, 0.4],
+        "pos" => &[0.3, 0.6, 0.7],
+        "deal_amount" => &[100.0, 400.0, 50.0],
+        "value" => &[1000.0, 200.0, 800.0],
+    }?;
+
+    let mean = indicator_analysis(&frame, IndicatorMethod::Mean)?;
+    let amount = indicator_analysis(&frame, IndicatorMethod::AmountWeighted)?;
+    let value = indicator_analysis(&frame, IndicatorMethod::ValueWeighted)?;
+
+    let extract = |df: &DataFrame, indicator: &str| -> f64 {
+        df.column("indicator")
+            .unwrap()
+            .utf8()
+            .unwrap()
+            .into_iter()
+            .zip(df.column("value").unwrap().f64().unwrap().into_iter())
+            .find_map(|(name, value)| match (name, value) {
+                (Some(name), Some(value)) if name == indicator => Some(value),
+                _ => None,
+            })
+            .unwrap()
+    };
+
+    assert_abs_diff_eq!(extract(&mean, "ffr"), 0.6714285714285715, epsilon = 1e-12);
+    assert_abs_diff_eq!(extract(&mean, "pa"), 0.48571428571428577, epsilon = 1e-12);
+    assert_abs_diff_eq!(extract(&mean, "pos"), 0.6142857142857143, epsilon = 1e-12);
+
+    assert_abs_diff_eq!(extract(&amount, "ffr"), 0.4636363636363636, epsilon = 1e-12);
+    assert_abs_diff_eq!(extract(&amount, "pa"), 0.6545454545454545, epsilon = 1e-12);
+    assert_abs_diff_eq!(extract(&amount, "pos"), 0.6142857142857143, epsilon = 1e-12);
+
+    assert_abs_diff_eq!(extract(&value, "ffr"), 0.46, epsilon = 1e-12);
+    assert_abs_diff_eq!(extract(&value, "pa"), 0.34, epsilon = 1e-12);
+    assert_abs_diff_eq!(extract(&value, "pos"), 0.6142857142857143, epsilon = 1e-12);
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add frequency-aware metrics evaluation helpers plus indicator analysis parity with the Python implementation
- export the expanded metrics surface and update documentation with usage examples
- extend regression tests and task tracking to cover the new evaluation capabilities

## Testing
- cargo fmt --manifest-path qliber/Cargo.toml
- cargo clippy --manifest-path qliber/Cargo.toml -- -D warnings
- cargo test --manifest-path qliber/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68df3dbb5130832b83b638fec00b3a8d