### PR TITLE
Add portfolio analytics parity with qlib

### DIFF
--- a/qliber/README.md
+++ b/qliber/README.md
@@ -22,6 +22,8 @@ qliber mirrors these building blocks with the following Rust-native equivalents:
 - **Workflow & Evaluation → `metrics` module:** cumulative/annualized return aggregation, Sharpe/information ratios,
   and drawdown metrics with both arithmetic and geometric accumulation modes, frequency-aware scaling,
   and trade indicator weighting analysis that mirrors Qlib's Python helpers.
+- **Portfolio Evaluation → `portfolio` module:** position valuation, portfolio-level return series, Sharpe/alpha/beta,
+  and information coefficient utilities aligned with `qlib.contrib.evaluate_portfolio` semantics.
 
 This initial slice prioritizes correctness and extensibility; additional modules such as model training or portfolio optimization can be layered atop these primitives in follow-up iterations.
 
@@ -46,8 +48,10 @@ qliber/
 ```rust
 use chrono::Utc;
 use qliber::{
-    indicator_analysis, with_daily_returns, with_moving_average, with_z_score, AccumulationMode,
-    IndicatorMethod, MarketData, PerformanceMetrics,
+    alpha, annual_return_from_returns, beta, indicator_analysis, max_drawdown_from_returns,
+    rank_information_coefficient, with_daily_returns, with_moving_average, with_z_score,
+    AccumulationMode, Holding, IndicatorMethod, InterestMethod, MarketData, PerformanceMetrics,
+    PortfolioSnapshot, PriceMatrix,
 };
 
 fn main() -> anyhow::Result<()> {
@@ -91,6 +95,46 @@ fn main() -> anyhow::Result<()> {
     let value_weighted = qliber::indicator_analysis_with_method(&trade_frame, "value_weighted")?;
     println!("Risk analysis:\n{}", risk_frame);
     println!("Value-weighted indicators:\n{}", value_weighted);
+
+    // Portfolio evaluation helpers mirroring qlib.contrib.evaluate_portfolio
+    let price_frame = polars::df! {
+        "date" => &["2024-01-02", "2024-01-03"],
+        "AAA" => &[10.0, 11.0],
+        "BBB" => &[20.0, 21.0],
+    }?;
+    let prices = PriceMatrix::from_dataframe(&price_frame, "date")?;
+    let mut day1 = PortfolioSnapshot::with_cash(50.0);
+    day1.insert_holding("AAA", Holding::new(5.0, None));
+    let mut day2 = PortfolioSnapshot::with_cash(50.0);
+    day2.insert_holding("AAA", Holding::new(5.0, None));
+    let mut positions = std::collections::BTreeMap::new();
+    positions.insert(chrono::NaiveDate::from_ymd_opt(2024, 1, 2).unwrap(), day1);
+    positions.insert(chrono::NaiveDate::from_ymd_opt(2024, 1, 3).unwrap(), day2);
+
+    let portfolio_returns = qliber::daily_return_series(&positions, &prices, 100.0)?;
+    let sharpe = qliber::sharpe_ratio_from_returns(
+        &portfolio_returns.iter().map(|(_, r)| *r).collect::<Vec<_>>(),
+        0.02,
+        InterestMethod::Compound,
+        252.0,
+    );
+    let alpha_value = alpha(
+        &returns,
+        &returns, // placeholder benchmark
+        0.02,
+        InterestMethod::Compound,
+        252.0,
+    )?;
+    let beta_value = beta(&returns, &returns)?;
+    let rank_ic = rank_information_coefficient(&returns, &returns)?;
+    let max_dd = max_drawdown_from_returns(&returns);
+    let annual = annual_return_from_returns(&returns, InterestMethod::Compound, 252.0);
+
+    println!("Portfolio daily returns: {:?}", portfolio_returns);
+    println!("Sharpe ratio: {:.3}", sharpe);
+    println!("Alpha: {:.3}, Beta: {:.3}", alpha_value, beta_value);
+    println!("Rank IC: {:.3}, Max Drawdown: {:.3}", rank_ic, max_dd);
+    println!("Annualized return: {:.3}", annual);
 
     Ok(())
 }

--- a/qliber/src/lib.rs
+++ b/qliber/src/lib.rs
@@ -6,6 +6,7 @@ pub mod dataset;
 pub mod features;
 pub mod logging;
 pub mod metrics;
+pub mod portfolio;
 
 pub use dataset::{DatasetError, MarketData};
 pub use features::{with_daily_returns, with_moving_average, with_z_score};
@@ -13,6 +14,12 @@ pub use metrics::{
     AccumulationMode, AnalysisFrequency, FrequencyUnit, IndicatorMethod, MetricsError,
     MetricsResult, PerformanceMetrics, indicator_analysis, indicator_analysis_with_method,
     risk_analysis,
+};
+pub use portfolio::{
+    Holding, InterestMethod, PortfolioError, PortfolioResult, PortfolioSnapshot, PriceMatrix,
+    alpha, annual_return_from_positions, annual_return_from_returns, beta, daily_return_series,
+    information_coefficient, max_drawdown_from_returns, position_value, position_value_series,
+    rank_information_coefficient, sharpe_ratio_from_returns, volatility,
 };
 
 pub type Result<T> = anyhow::Result<T>;

--- a/qliber/src/portfolio.rs
+++ b/qliber/src/portfolio.rs
@@ -1,0 +1,724 @@
+use std::collections::{BTreeMap, HashMap};
+use std::str::FromStr;
+
+use chrono::{DateTime, NaiveDate, Utc};
+use polars::prelude::*;
+use rayon::prelude::*;
+use thiserror::Error;
+
+use crate::logging::log_event;
+
+#[derive(Debug, Error)]
+pub enum PortfolioError {
+    #[error("polars error: {0}")]
+    Polars(#[from] PolarsError),
+    #[error("date column `{0}` not found in DataFrame")]
+    MissingDateColumn(String),
+    #[error("date column `{0}` has unsupported dtype {1}")]
+    UnsupportedDateType(String, String),
+    #[error("price for symbol `{symbol}` missing on {date}")]
+    MissingPrice { date: NaiveDate, symbol: String },
+    #[error("portfolio contains no positions")]
+    EmptyPositions,
+    #[error("insufficient overlapping observations for correlation/beta calculations")]
+    InsufficientObservations,
+    #[error("invalid interest method `{0}`; expected `ci` or `si`")]
+    InvalidInterestMethod(String),
+}
+
+pub type PortfolioResult<T> = Result<T, PortfolioError>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InterestMethod {
+    Compound,
+    Simple,
+}
+
+impl FromStr for InterestMethod {
+    type Err = PortfolioError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "ci" | "compound" => Ok(InterestMethod::Compound),
+            "si" | "simple" => Ok(InterestMethod::Simple),
+            other => Err(PortfolioError::InvalidInterestMethod(other.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Holding {
+    pub amount: f64,
+    pub price: Option<f64>,
+}
+
+impl Holding {
+    pub fn new(amount: f64, price: Option<f64>) -> Self {
+        Self { amount, price }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PortfolioSnapshot {
+    pub holdings: BTreeMap<String, Holding>,
+    pub cash: f64,
+}
+
+impl PortfolioSnapshot {
+    pub fn new(holdings: BTreeMap<String, Holding>, cash: f64) -> Self {
+        Self { holdings, cash }
+    }
+
+    pub fn with_cash(cash: f64) -> Self {
+        Self {
+            holdings: BTreeMap::new(),
+            cash,
+        }
+    }
+
+    pub fn insert_holding(&mut self, symbol: impl Into<String>, holding: Holding) {
+        self.holdings.insert(symbol.into(), holding);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PriceMatrix {
+    data: BTreeMap<NaiveDate, HashMap<String, f64>>,
+}
+
+impl PriceMatrix {
+    pub fn from_dataframe(frame: &DataFrame, date_column: &str) -> PortfolioResult<Self> {
+        let date_series = frame
+            .column(date_column)
+            .map_err(|_| PortfolioError::MissingDateColumn(date_column.to_string()))?;
+
+        let dates = extract_dates(date_series, date_column)?;
+        let mut data: BTreeMap<NaiveDate, HashMap<String, f64>> = BTreeMap::new();
+
+        let mut price_columns = Vec::new();
+        for column in frame.get_columns() {
+            if column.name() != date_column {
+                let converted = series_to_f64(column)?;
+                price_columns.push((column.name().to_string(), converted));
+            }
+        }
+
+        for (row_idx, date) in dates.iter().enumerate() {
+            let mut row = HashMap::new();
+            for (name, column) in &price_columns {
+                match column.get(row_idx) {
+                    Some(value) if value.is_finite() => {
+                        row.insert(name.clone(), value);
+                    }
+                    _ => {
+                        return Err(PortfolioError::MissingPrice {
+                            date: *date,
+                            symbol: name.clone(),
+                        });
+                    }
+                }
+            }
+            data.insert(*date, row);
+        }
+
+        log_event(
+            file!(),
+            "PriceMatrix",
+            "from_dataframe",
+            "portfolio.prices",
+            line!(),
+            &format!(
+                "Constructed price matrix with {} rows and {} symbols",
+                data.len(),
+                price_columns.len()
+            ),
+            None,
+            "none",
+            "GET",
+        );
+
+        Ok(Self { data })
+    }
+
+    pub fn price(&self, date: &NaiveDate, symbol: &str) -> Option<f64> {
+        self.data.get(date).and_then(|row| row.get(symbol)).copied()
+    }
+
+    pub fn dates(&self) -> impl Iterator<Item = &NaiveDate> {
+        self.data.keys()
+    }
+}
+
+pub fn position_value(
+    snapshot: &PortfolioSnapshot,
+    prices: &PriceMatrix,
+    date: NaiveDate,
+) -> PortfolioResult<f64> {
+    let mut total = snapshot.cash;
+
+    for (symbol, holding) in &snapshot.holdings {
+        let price = prices
+            .price(&date, symbol)
+            .ok_or_else(|| PortfolioError::MissingPrice {
+                date,
+                symbol: symbol.clone(),
+            })?;
+        total += holding.amount * price;
+    }
+
+    log_event(
+        file!(),
+        "PortfolioAnalytics",
+        "position_value",
+        "portfolio.valuation",
+        line!(),
+        &format!(
+            "Computed portfolio value on {date} across {} holdings",
+            snapshot.holdings.len()
+        ),
+        None,
+        "none",
+        "GET",
+    );
+
+    Ok(total)
+}
+
+pub fn position_value_series(
+    positions: &BTreeMap<NaiveDate, PortfolioSnapshot>,
+    prices: &PriceMatrix,
+) -> PortfolioResult<BTreeMap<NaiveDate, f64>> {
+    if positions.is_empty() {
+        return Err(PortfolioError::EmptyPositions);
+    }
+
+    let mut series = BTreeMap::new();
+    for (date, snapshot) in positions {
+        let value = position_value(snapshot, prices, *date)?;
+        series.insert(*date, value);
+    }
+
+    log_event(
+        file!(),
+        "PortfolioAnalytics",
+        "position_value_series",
+        "portfolio.valuation",
+        line!(),
+        &format!("Evaluated {} position snapshots", series.len()),
+        None,
+        "none",
+        "GET",
+    );
+
+    Ok(series)
+}
+
+pub fn daily_return_series(
+    positions: &BTreeMap<NaiveDate, PortfolioSnapshot>,
+    prices: &PriceMatrix,
+    init_asset_value: f64,
+) -> PortfolioResult<Vec<(NaiveDate, f64)>> {
+    let series = position_value_series(positions, prices)?;
+    let mut returns = Vec::new();
+    let mut prev_value: Option<f64> = None;
+
+    for (idx, (date, value)) in series.iter().enumerate() {
+        let daily = if idx == 0 {
+            value / init_asset_value - 1.0
+        } else if let Some(prev) = prev_value {
+            if prev.abs() <= f64::EPSILON {
+                0.0
+            } else {
+                value / prev - 1.0
+            }
+        } else {
+            0.0
+        };
+        returns.push((*date, daily));
+        prev_value = Some(*value);
+    }
+
+    log_event(
+        file!(),
+        "PortfolioAnalytics",
+        "daily_return_series",
+        "portfolio.returns",
+        line!(),
+        &format!("Computed {} daily returns", returns.len()),
+        None,
+        "none",
+        "GET",
+    );
+
+    Ok(returns)
+}
+
+pub fn annual_return_from_positions(
+    positions: &BTreeMap<NaiveDate, PortfolioSnapshot>,
+    prices: &PriceMatrix,
+    init_asset_value: f64,
+    periods_per_year: f64,
+) -> PortfolioResult<f64> {
+    let series = position_value_series(positions, prices)?;
+    let count = series.len();
+    if count == 0 {
+        return Err(PortfolioError::EmptyPositions);
+    }
+
+    let final_value = series.values().last().copied().unwrap_or(init_asset_value);
+    let n_period = count as f64;
+    let annual = if init_asset_value <= f64::EPSILON {
+        0.0
+    } else {
+        (final_value / init_asset_value).powf(periods_per_year / n_period) - 1.0
+    };
+
+    log_event(
+        file!(),
+        "PortfolioAnalytics",
+        "annual_return_from_positions",
+        "portfolio.returns",
+        line!(),
+        &format!(
+            "Annualized portfolio return {:.6} over {} periods",
+            annual, count
+        ),
+        None,
+        "none",
+        "GET",
+    );
+
+    Ok(annual)
+}
+
+pub fn annual_return_from_returns(
+    returns: &[f64],
+    method: InterestMethod,
+    periods_per_year: f64,
+) -> f64 {
+    let clean_returns: Vec<f64> = returns
+        .iter()
+        .copied()
+        .filter(|value| value.is_finite())
+        .collect();
+
+    if clean_returns.is_empty() {
+        return 0.0;
+    }
+
+    let mean = clean_returns.iter().copied().sum::<f64>() / clean_returns.len() as f64;
+
+    let annual = match method {
+        InterestMethod::Compound => (1.0 + mean).powf(periods_per_year) - 1.0,
+        InterestMethod::Simple => mean * periods_per_year,
+    };
+
+    log_event(
+        file!(),
+        "PortfolioAnalytics",
+        "annual_return_from_returns",
+        "portfolio.returns",
+        line!(),
+        &format!(
+            "Computed annual return {:.6} using {:?} method",
+            annual, method
+        ),
+        None,
+        "none",
+        "GET",
+    );
+
+    annual
+}
+
+pub fn sharpe_ratio_from_returns(
+    returns: &[f64],
+    risk_free_rate: f64,
+    method: InterestMethod,
+    periods_per_year: f64,
+) -> f64 {
+    let clean_returns: Vec<f64> = returns
+        .iter()
+        .copied()
+        .filter(|value| value.is_finite())
+        .collect();
+
+    if clean_returns.len() < 2 {
+        return 0.0;
+    }
+
+    let mean = clean_returns.iter().copied().sum::<f64>() / clean_returns.len() as f64;
+    let variance = sample_variance(&clean_returns, mean);
+    let std_dev = variance.sqrt();
+    if std_dev <= f64::EPSILON {
+        return 0.0;
+    }
+
+    let annual = annual_return_from_returns(&clean_returns, method, periods_per_year);
+    let sharpe = (annual - risk_free_rate) / std_dev / periods_per_year.sqrt();
+
+    log_event(
+        file!(),
+        "PortfolioAnalytics",
+        "sharpe_ratio_from_returns",
+        "portfolio.risk",
+        line!(),
+        &format!(
+            "Computed Sharpe ratio {:.6} with risk-free rate {:.4}",
+            sharpe, risk_free_rate
+        ),
+        None,
+        "none",
+        "GET",
+    );
+
+    sharpe
+}
+
+pub fn max_drawdown_from_returns(returns: &[f64]) -> f64 {
+    let clean_returns: Vec<f64> = returns
+        .iter()
+        .copied()
+        .filter(|value| value.is_finite())
+        .collect();
+
+    if clean_returns.is_empty() {
+        return 0.0;
+    }
+
+    let mut cumulative = 1.0;
+    let mut peak = 1.0;
+    let mut max_drawdown = 0.0;
+
+    for value in clean_returns {
+        cumulative *= 1.0 + value;
+        if cumulative > peak {
+            peak = cumulative;
+        }
+        let drawdown = (cumulative / peak) - 1.0;
+        if drawdown < max_drawdown {
+            max_drawdown = drawdown;
+        }
+    }
+
+    log_event(
+        file!(),
+        "PortfolioAnalytics",
+        "max_drawdown_from_returns",
+        "portfolio.risk",
+        line!(),
+        &format!("Computed max drawdown {:.6}", max_drawdown),
+        None,
+        "none",
+        "GET",
+    );
+
+    max_drawdown
+}
+
+pub fn beta(returns: &[f64], benchmark: &[f64]) -> PortfolioResult<f64> {
+    let (clean_r, clean_b) = align_series(returns, benchmark);
+    if clean_r.len() < 2 {
+        return Err(PortfolioError::InsufficientObservations);
+    }
+
+    let cov = covariance(&clean_r, &clean_b);
+    let var_b = variance(&clean_b);
+    if var_b <= f64::EPSILON {
+        return Err(PortfolioError::InsufficientObservations);
+    }
+
+    let beta = cov / var_b;
+
+    log_event(
+        file!(),
+        "PortfolioAnalytics",
+        "beta",
+        "portfolio.risk",
+        line!(),
+        &format!("Computed beta {:.6}", beta),
+        None,
+        "none",
+        "GET",
+    );
+
+    Ok(beta)
+}
+
+pub fn alpha(
+    returns: &[f64],
+    benchmark: &[f64],
+    risk_free_rate: f64,
+    method: InterestMethod,
+    periods_per_year: f64,
+) -> PortfolioResult<f64> {
+    let beta_val = beta(returns, benchmark)?;
+    let annual_r = annual_return_from_returns(returns, method, periods_per_year);
+    let annual_b = annual_return_from_returns(benchmark, method, periods_per_year);
+    let alpha = annual_r - risk_free_rate - beta_val * (annual_b - risk_free_rate);
+
+    log_event(
+        file!(),
+        "PortfolioAnalytics",
+        "alpha",
+        "portfolio.risk",
+        line!(),
+        &format!("Computed alpha {:.6}", alpha),
+        None,
+        "none",
+        "GET",
+    );
+
+    Ok(alpha)
+}
+
+pub fn volatility(returns: &[f64]) -> f64 {
+    let clean_returns: Vec<f64> = returns
+        .iter()
+        .copied()
+        .filter(|value| value.is_finite())
+        .collect();
+
+    if clean_returns.len() < 2 {
+        return 0.0;
+    }
+
+    let mean = clean_returns.iter().copied().sum::<f64>() / clean_returns.len() as f64;
+    let variance = sample_variance(&clean_returns, mean);
+    let vol = variance.sqrt();
+
+    log_event(
+        file!(),
+        "PortfolioAnalytics",
+        "volatility",
+        "portfolio.risk",
+        line!(),
+        &format!("Computed volatility {:.6}", vol),
+        None,
+        "none",
+        "GET",
+    );
+
+    vol
+}
+
+pub fn rank_information_coefficient(a: &[f64], b: &[f64]) -> PortfolioResult<f64> {
+    let (clean_a, clean_b) = align_series(a, b);
+    if clean_a.len() < 2 {
+        return Err(PortfolioError::InsufficientObservations);
+    }
+
+    let ranks_a = average_ranks(&clean_a);
+    let ranks_b = average_ranks(&clean_b);
+    let ic = pearson_correlation(&ranks_a, &ranks_b).unwrap_or(0.0);
+
+    log_event(
+        file!(),
+        "PortfolioAnalytics",
+        "rank_information_coefficient",
+        "portfolio.correlation",
+        line!(),
+        &format!("Computed rank IC {:.6}", ic),
+        None,
+        "none",
+        "GET",
+    );
+
+    Ok(ic)
+}
+
+pub fn information_coefficient(a: &[f64], b: &[f64]) -> PortfolioResult<f64> {
+    let (clean_a, clean_b) = align_series(a, b);
+    if clean_a.len() < 2 {
+        return Err(PortfolioError::InsufficientObservations);
+    }
+
+    let ic = pearson_correlation(&clean_a, &clean_b).unwrap_or(0.0);
+
+    log_event(
+        file!(),
+        "PortfolioAnalytics",
+        "information_coefficient",
+        "portfolio.correlation",
+        line!(),
+        &format!("Computed normal IC {:.6}", ic),
+        None,
+        "none",
+        "GET",
+    );
+
+    Ok(ic)
+}
+
+fn extract_dates(series: &Series, name: &str) -> PortfolioResult<Vec<NaiveDate>> {
+    match series.dtype() {
+        DataType::Date => {
+            let casted = series.cast(&DataType::Datetime(TimeUnit::Milliseconds, None))?;
+            extract_from_datetime(&casted)
+        }
+        DataType::Datetime(_, _) => extract_from_datetime(series),
+        DataType::Utf8 => {
+            let utf8 = series.utf8()?;
+            let mut dates = Vec::with_capacity(utf8.len());
+            for value in utf8.into_iter() {
+                if let Some(value) = value {
+                    let date = NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                        .or_else(|_| NaiveDate::parse_from_str(value, "%Y/%m/%d"))
+                        .map_err(|_| {
+                            PortfolioError::UnsupportedDateType(
+                                name.to_string(),
+                                "utf8 string".to_string(),
+                            )
+                        })?;
+                    dates.push(date);
+                } else {
+                    return Err(PortfolioError::UnsupportedDateType(
+                        name.to_string(),
+                        "null".to_string(),
+                    ));
+                }
+            }
+            Ok(dates)
+        }
+        other => Err(PortfolioError::UnsupportedDateType(
+            name.to_string(),
+            format!("{other:?}"),
+        )),
+    }
+}
+
+fn extract_from_datetime(series: &Series) -> PortfolioResult<Vec<NaiveDate>> {
+    let dtype_description = format!("{:?}", series.dtype());
+    let datetime = series.datetime().map_err(|_| {
+        PortfolioError::UnsupportedDateType(series.name().to_string(), dtype_description.clone())
+    })?;
+    let mut dates = Vec::with_capacity(datetime.len());
+    for value in datetime.into_iter() {
+        if let Some(millis) = value {
+            if let Some(dt) = DateTime::<Utc>::from_timestamp_millis(millis) {
+                dates.push(dt.date_naive());
+            } else {
+                return Err(PortfolioError::UnsupportedDateType(
+                    series.name().to_string(),
+                    "out-of-range datetime".to_string(),
+                ));
+            }
+        } else {
+            return Err(PortfolioError::UnsupportedDateType(
+                series.name().to_string(),
+                "null".to_string(),
+            ));
+        }
+    }
+    Ok(dates)
+}
+
+fn series_to_f64(series: &Series) -> PortfolioResult<Float64Chunked> {
+    if matches!(series.dtype(), DataType::Float64) {
+        Ok(series.f64()?.clone())
+    } else {
+        let casted = series.cast(&DataType::Float64)?;
+        Ok(casted.f64().expect("series cast to f64").clone())
+    }
+}
+
+fn align_series(a: &[f64], b: &[f64]) -> (Vec<f64>, Vec<f64>) {
+    a.iter()
+        .copied()
+        .zip(b.iter().copied())
+        .filter(|(x, y)| x.is_finite() && y.is_finite())
+        .unzip()
+}
+
+fn sample_variance(values: &[f64], mean: f64) -> f64 {
+    if values.len() < 2 {
+        return 0.0;
+    }
+
+    let sum_squares = values
+        .par_iter()
+        .map(|value| {
+            let diff = value - mean;
+            diff * diff
+        })
+        .sum::<f64>();
+    sum_squares / (values.len() as f64 - 1.0)
+}
+
+fn variance(values: &[f64]) -> f64 {
+    if values.len() < 2 {
+        return 0.0;
+    }
+
+    let mean = values.iter().copied().sum::<f64>() / values.len() as f64;
+    sample_variance(values, mean)
+}
+
+fn covariance(a: &[f64], b: &[f64]) -> f64 {
+    if a.len() != b.len() || a.len() < 2 {
+        return 0.0;
+    }
+
+    let mean_a = a.iter().copied().sum::<f64>() / a.len() as f64;
+    let mean_b = b.iter().copied().sum::<f64>() / b.len() as f64;
+
+    let cov_sum: f64 = a
+        .iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - mean_a) * (y - mean_b))
+        .sum();
+    cov_sum / (a.len() as f64 - 1.0)
+}
+
+fn pearson_correlation(a: &[f64], b: &[f64]) -> Option<f64> {
+    if a.len() != b.len() || a.len() < 2 {
+        return None;
+    }
+
+    let mean_a = a.iter().copied().sum::<f64>() / a.len() as f64;
+    let mean_b = b.iter().copied().sum::<f64>() / b.len() as f64;
+
+    let mut numerator = 0.0;
+    let mut denom_a = 0.0;
+    let mut denom_b = 0.0;
+
+    for (x, y) in a.iter().zip(b.iter()) {
+        let dx = x - mean_a;
+        let dy = y - mean_b;
+        numerator += dx * dy;
+        denom_a += dx * dx;
+        denom_b += dy * dy;
+    }
+
+    let denominator = (denom_a * denom_b).sqrt();
+    if denominator <= f64::EPSILON {
+        None
+    } else {
+        Some(numerator / denominator)
+    }
+}
+
+fn average_ranks(values: &[f64]) -> Vec<f64> {
+    let mut indexed: Vec<(usize, f64)> = values.iter().copied().enumerate().collect();
+    indexed.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut ranks = vec![0.0; values.len()];
+    let mut i = 0;
+    while i < indexed.len() {
+        let start = i;
+        let value = indexed[i].1;
+        let mut end = i + 1;
+        while end < indexed.len() && indexed[end].1 == value {
+            end += 1;
+        }
+        let first_rank = start + 1;
+        let last_rank = end;
+        let average_rank = (first_rank + last_rank) as f64 / 2.0;
+        for (original, _) in indexed[start..end].iter() {
+            ranks[*original] = average_rank;
+        }
+        i = end;
+    }
+
+    ranks
+}

--- a/qliber/task.md
+++ b/qliber/task.md
@@ -19,3 +19,7 @@
 - [x] Extend tests to validate scaler/frequency handling and Python mode parity
 - [x] Document the parity helpers in the README for downstream consumers
 - [x] Ensure Rust risk metrics filter non-finite returns to match Python semantics
+- [x] Review qlib.contrib.evaluate_portfolio parity gaps and define required Rust APIs
+- [x] Port portfolio analytics (position valuation, return series, annual metrics) to Rust
+- [x] Expand regression tests to cover the new portfolio analytics surface
+- [x] Document the portfolio module additions in the README

--- a/qliber/tests/portfolio.rs
+++ b/qliber/tests/portfolio.rs
@@ -1,0 +1,214 @@
+use std::collections::BTreeMap;
+
+use chrono::NaiveDate;
+use polars::prelude::*;
+use qliber::portfolio::{PortfolioSnapshot, PriceMatrix};
+use qliber::{
+    Holding, InterestMethod, alpha, annual_return_from_positions, annual_return_from_returns, beta,
+    daily_return_series, information_coefficient, max_drawdown_from_returns, position_value,
+    position_value_series, rank_information_coefficient, sharpe_ratio_from_returns, volatility,
+};
+
+fn sample_price_matrix() -> PriceMatrix {
+    let frame = df! {
+        "date" => &["2024-01-02", "2024-01-03", "2024-01-04"],
+        "AAA" => &[10.0, 11.0, 10.5],
+        "BBB" => &[20.0, 19.5, 20.5],
+    }
+    .unwrap();
+
+    PriceMatrix::from_dataframe(&frame, "date").expect("build price matrix")
+}
+
+fn sample_positions() -> BTreeMap<NaiveDate, PortfolioSnapshot> {
+    let mut positions = BTreeMap::new();
+    let mut snapshot = PortfolioSnapshot::with_cash(60.0);
+    snapshot.insert_holding("AAA", Holding::new(5.0, None));
+    snapshot.insert_holding("BBB", Holding::new(2.0, None));
+    positions.insert(
+        NaiveDate::from_ymd_opt(2024, 1, 2).unwrap(),
+        snapshot.clone(),
+    );
+
+    let mut snapshot_next = PortfolioSnapshot::with_cash(60.0);
+    snapshot_next.insert_holding("AAA", Holding::new(5.0, None));
+    snapshot_next.insert_holding("BBB", Holding::new(2.0, None));
+    positions.insert(
+        NaiveDate::from_ymd_opt(2024, 1, 3).unwrap(),
+        snapshot_next.clone(),
+    );
+
+    let mut snapshot_final = PortfolioSnapshot::with_cash(60.0);
+    snapshot_final.insert_holding("AAA", Holding::new(5.0, None));
+    snapshot_final.insert_holding("BBB", Holding::new(2.0, None));
+    positions.insert(
+        NaiveDate::from_ymd_opt(2024, 1, 4).unwrap(),
+        snapshot_final.clone(),
+    );
+
+    positions
+}
+
+#[test]
+fn test_price_matrix_and_position_values() {
+    let prices = sample_price_matrix();
+    let positions = sample_positions();
+
+    let first_date = NaiveDate::from_ymd_opt(2024, 1, 2).unwrap();
+    let first_value = position_value(&positions[&first_date], &prices, first_date).unwrap();
+    let expected_first = 5.0 * 10.0 + 2.0 * 20.0 + 60.0;
+    assert!((first_value - expected_first).abs() < 1e-9);
+
+    let series = position_value_series(&positions, &prices).unwrap();
+    let values: Vec<f64> = series.values().copied().collect();
+    assert_eq!(values.len(), 3);
+    let expected_second = 5.0 * 11.0 + 2.0 * 19.5 + 60.0;
+    let expected_third = 5.0 * 10.5 + 2.0 * 20.5 + 60.0;
+    assert!((values[0] - expected_first).abs() < 1e-9);
+    assert!((values[1] - expected_second).abs() < 1e-9);
+    assert!((values[2] - expected_third).abs() < 1e-9);
+}
+
+#[test]
+fn test_return_series_and_annualization() {
+    let prices = sample_price_matrix();
+    let positions = sample_positions();
+    let returns = daily_return_series(&positions, &prices, 150.0).unwrap();
+    assert_eq!(returns.len(), 3);
+    assert!((returns[0].1 - 0.0).abs() < 1e-9);
+
+    let second_value = 5.0 * 11.0 + 2.0 * 19.5 + 60.0;
+    let third_value = 5.0 * 10.5 + 2.0 * 20.5 + 60.0;
+    let expected_second = second_value / 150.0 - 1.0;
+    let expected_third = third_value / second_value - 1.0;
+    assert!((returns[1].1 - expected_second).abs() < 1e-9);
+    assert!((returns[2].1 - expected_third).abs() < 1e-9);
+
+    let annual = annual_return_from_positions(&positions, &prices, 150.0, 252.0).unwrap();
+    let final_value = third_value;
+    let expected = (final_value / 150.0).powf(252.0 / 3.0) - 1.0;
+    assert!((annual - expected).abs() < 1e-9);
+}
+
+#[test]
+fn test_risk_helpers_from_returns() {
+    let returns = vec![0.01, -0.005, 0.02, 0.015, -0.01];
+    let annual_compound = annual_return_from_returns(&returns, InterestMethod::Compound, 252.0);
+    let annual_simple = annual_return_from_returns(&returns, InterestMethod::Simple, 252.0);
+    let mean = returns.iter().copied().sum::<f64>() / returns.len() as f64;
+    let variance = returns
+        .iter()
+        .map(|r| {
+            let diff = r - mean;
+            diff * diff
+        })
+        .sum::<f64>()
+        / (returns.len() as f64 - 1.0);
+    let std = variance.sqrt();
+
+    let expected_compound = (1.0 + mean).powf(252.0) - 1.0;
+    let expected_simple = mean * 252.0;
+    assert!((annual_compound - expected_compound).abs() < 1e-9);
+    assert!((annual_simple - expected_simple).abs() < 1e-9);
+
+    let sharpe = sharpe_ratio_from_returns(&returns, 0.02, InterestMethod::Compound, 252.0);
+    let expected_sharpe = (annual_compound - 0.02) / std / 252f64.sqrt();
+    assert!((sharpe - expected_sharpe).abs() < 1e-9);
+
+    let mdd = max_drawdown_from_returns(&returns);
+    let mut cumulative = 1.0;
+    let mut peak = 1.0;
+    let mut expected_mdd = 0.0;
+    for value in &returns {
+        cumulative *= 1.0 + value;
+        if cumulative > peak {
+            peak = cumulative;
+        }
+        let drawdown = (cumulative / peak) - 1.0;
+        if drawdown < expected_mdd {
+            expected_mdd = drawdown;
+        }
+    }
+    assert!((mdd - expected_mdd).abs() < 1e-9);
+
+    let vol = volatility(&returns);
+    assert!((vol - std).abs() < 1e-9);
+}
+
+#[test]
+fn test_beta_and_alpha_and_ic() {
+    let strategy = vec![0.01, 0.015, 0.0, 0.02, -0.005];
+    let benchmark = vec![0.005, 0.007, -0.002, 0.01, 0.0];
+
+    let beta_val = beta(&strategy, &benchmark).unwrap();
+    let mean_strategy = strategy.iter().copied().sum::<f64>() / strategy.len() as f64;
+    let mean_benchmark = benchmark.iter().copied().sum::<f64>() / benchmark.len() as f64;
+    let cov = strategy
+        .iter()
+        .zip(benchmark.iter())
+        .map(|(s, b)| (s - mean_strategy) * (b - mean_benchmark))
+        .sum::<f64>()
+        / (strategy.len() as f64 - 1.0);
+    let var_b = benchmark
+        .iter()
+        .map(|b| {
+            let diff = b - mean_benchmark;
+            diff * diff
+        })
+        .sum::<f64>()
+        / (benchmark.len() as f64 - 1.0);
+    let expected_beta = cov / var_b;
+    assert!((beta_val - expected_beta).abs() < 1e-9);
+
+    let alpha_val = alpha(&strategy, &benchmark, 0.02, InterestMethod::Compound, 252.0).unwrap();
+    let annual_strategy = annual_return_from_returns(&strategy, InterestMethod::Compound, 252.0);
+    let annual_benchmark = annual_return_from_returns(&benchmark, InterestMethod::Compound, 252.0);
+    let expected_alpha = annual_strategy - 0.02 - expected_beta * (annual_benchmark - 0.02);
+    assert!((alpha_val - expected_alpha).abs() < 1e-9);
+
+    let rank_ic = rank_information_coefficient(&strategy, &benchmark).unwrap();
+    let mut strat_ranks: Vec<(usize, f64)> = strategy.iter().copied().enumerate().collect();
+    strat_ranks.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+    let mut bench_ranks: Vec<(usize, f64)> = benchmark.iter().copied().enumerate().collect();
+    bench_ranks.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+    let mut strat_rank_vec = vec![0.0; strategy.len()];
+    let mut bench_rank_vec = vec![0.0; benchmark.len()];
+    for (rank, (idx, _)) in strat_ranks.iter().enumerate() {
+        strat_rank_vec[*idx] = (rank + 1) as f64;
+    }
+    for (rank, (idx, _)) in bench_ranks.iter().enumerate() {
+        bench_rank_vec[*idx] = (rank + 1) as f64;
+    }
+    let diffs: Vec<f64> = strat_rank_vec
+        .iter()
+        .zip(bench_rank_vec.iter())
+        .map(|(a, b)| a - b)
+        .collect();
+    let sum_diff_sq: f64 = diffs.iter().map(|d| d * d).sum();
+    let n = strategy.len() as f64;
+    let expected_rank_ic = 1.0 - 6.0 * sum_diff_sq / (n * (n * n - 1.0));
+    assert!((rank_ic - expected_rank_ic).abs() < 1e-9);
+
+    let normal_ic = information_coefficient(&strategy, &benchmark).unwrap();
+    let numerator = strategy
+        .iter()
+        .zip(benchmark.iter())
+        .map(|(s, b)| (s - mean_strategy) * (b - mean_benchmark))
+        .sum::<f64>();
+    let denom_strategy = strategy
+        .iter()
+        .map(|s| {
+            let diff = s - mean_strategy;
+            diff * diff
+        })
+        .sum::<f64>();
+    let denom_benchmark = benchmark
+        .iter()
+        .map(|b| {
+            let diff = b - mean_benchmark;
+            diff * diff
+        })
+        .sum::<f64>();
+    let expected_normal_ic = numerator / (denom_strategy.sqrt() * denom_benchmark.sqrt());
+    assert!((normal_ic - expected_normal_ic).abs() < 1e-9);
+}


### PR DESCRIPTION
## Summary
- add a portfolio analytics module covering price ingestion, position valuation, return series, and risk/correlation metrics aligned with qlib.contrib.evaluate_portfolio
- expose the new APIs through the crate root, document usage in the README, and tick the corresponding task items
- add focused regression tests validating portfolio valuation, annualization, risk helpers, and alpha/beta/IC calculations

## Testing
- cargo fmt
- cargo clippy -- -D warnings
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e84f561494832bb21f7f55d779ef8f