### PR TITLE
docs: capture remaining parity tasks for qliber

### DIFF
--- a/qliber/task.md
+++ b/qliber/task.md
@@ -23,3 +23,14 @@
 - [x] Port portfolio analytics (position valuation, return series, annual metrics) to Rust
 - [x] Expand regression tests to cover the new portfolio analytics surface
 - [x] Document the portfolio module additions in the README
+- [ ] Port Qlib's provider infrastructure (calendars, instruments, feature caching/backends, and PIT storage) into Rust's dataset layer to match `qlib.data.data` and `qlib.data.storage` capabilities
+- [ ] Implement the configurable dataset handler/loader/processor pipeline (DataHandler, DataLoader, Processor stacks) to mirror `qlib.data.dataset` semantics for feature/label management
+- [ ] Recreate the expression operator engine (Operators, rolling/expanding stats, percentile utilities) covering the breadth of `qlib.data.ops`
+- [ ] Add remote data server compatibility, including the socket.io client protocol exposed in `qlib.data.client`, for distributed data access
+- [ ] Port the nested backtesting and execution stack (strategy decisions, executors, exchanges, profit attribution, reporting) from `qlib.backtest`
+- [ ] Expose portfolio and RL-aware strategy abstractions (`BaseStrategy`, interpreters) and integrate them with the backtest infrastructure found in `qlib.strategy`
+- [ ] Rebuild workflow & experiment management (Experiment manager, Recorder integrations, task manager hooks) analogous to `qlib.workflow`
+- [ ] Provide the model training pipeline (trainers, task orchestration, recorder persistence) covering the behaviors defined in `qlib.model.trainer`
+- [ ] Port the reinforcement learning framework (trainer vessel, simulators, order execution APIs) defined under `qlib.rl`
+- [ ] Ship CLI tooling (`qrun`, data preparation helpers) to orchestrate workflows like the Python `qlib.cli` package
+- [ ] Reimplement the contrib data handlers and factor templates (e.g., Alpha158/Alpha360 processors) from `qlib.contrib`


### PR DESCRIPTION
## Summary
- enumerate the remaining parity gaps with Python Qlib in `qliber/task.md`, covering data providers, dataset handlers, expression ops, remote data clients, backtesting, strategies, workflow, model training, RL, CLI, and contrib factor handlers

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e85395c908832b9eb075299c8fa40e