### PR TITLE
Add provider infrastructure module

### DIFF
--- a/qliber/README.md
+++ b/qliber/README.md
@@ -18,6 +18,7 @@ Microsoft Qlib delivers a research platform composed of three pillars: dataset i
 qliber mirrors these building blocks with the following Rust-native equivalents:
 
 - **Data Server → `dataset` module:** lazy CSV ingestion, column projection, and temporal filtering.
+- **Provider Infrastructure → `provider` module:** instrument registry, trading calendars, in-memory feature caching, and point-in-time storage primitives mirroring `qlib.data` providers.
 - **Feature Library → `features` module:** rolling statistics, return computation, and normalization helpers.
 - **Workflow & Evaluation → `metrics` module:** cumulative/annualized return aggregation, Sharpe/information ratios,
   and drawdown metrics with both arithmetic and geometric accumulation modes, frequency-aware scaling,
@@ -38,9 +39,12 @@ qliber/
 │   ├── features.rs     # Feature engineering helpers (returns, moving averages, z-scores)
 │   ├── logging.rs      # Structured logging initialization and helpers
 │   ├── metrics.rs      # Performance metric calculations (cumulative, annualized, ratios, drawdowns)
+│   ├── portfolio.rs    # Portfolio analytics matching qlib.contrib.evaluate_portfolio
+│   ├── provider.rs     # Trading calendars, instrument registry, feature caching, and PIT storage
 │   └── lib.rs          # Public crate exports
 └── tests
-    └── pipeline.rs     # End-to-end regression test covering the primary flow
+    ├── pipeline.rs     # End-to-end regression test covering the primary flow
+    └── provider.rs     # Provider infrastructure unit coverage (calendars, cache, PIT)
 ```
 
 ## Usage

--- a/qliber/src/lib.rs
+++ b/qliber/src/lib.rs
@@ -7,6 +7,7 @@ pub mod features;
 pub mod logging;
 pub mod metrics;
 pub mod portfolio;
+pub mod provider;
 
 pub use dataset::{DatasetError, MarketData};
 pub use features::{with_daily_returns, with_moving_average, with_z_score};
@@ -20,6 +21,11 @@ pub use portfolio::{
     alpha, annual_return_from_positions, annual_return_from_returns, beta, daily_return_series,
     information_coefficient, max_drawdown_from_returns, position_value, position_value_series,
     rank_information_coefficient, sharpe_ratio_from_returns, volatility,
+};
+pub use provider::{
+    DataProvider, DefaultDataProvider, FeatureBackend, FeatureKey, InMemoryFeatureBackend,
+    Instrument, InstrumentStore, PitRecord, PitStore, ProviderError, ProviderResult,
+    TradingCalendar,
 };
 
 pub type Result<T> = anyhow::Result<T>;

--- a/qliber/src/provider.rs
+++ b/qliber/src/provider.rs
@@ -1,0 +1,449 @@
+use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, RwLock};
+
+use chrono::{DateTime, NaiveDate, Utc};
+use polars::prelude::*;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::logging::log_event;
+
+type PitMap = HashMap<String, BTreeMap<DateTime<Utc>, DataFrame>>;
+
+#[derive(Debug, Error)]
+pub enum ProviderError {
+    #[error("calendar operation failed: {0}")]
+    Calendar(String),
+    #[error("instrument error: {0}")]
+    Instrument(String),
+    #[error("feature backend error: {0}")]
+    FeatureBackend(String),
+    #[error("pit storage error: {0}")]
+    Pit(String),
+}
+
+pub type ProviderResult<T> = Result<T, ProviderError>;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Instrument {
+    pub symbol: String,
+    pub start: NaiveDate,
+    pub end: Option<NaiveDate>,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+impl Instrument {
+    pub fn new<S: Into<String>>(symbol: S, start: NaiveDate, end: Option<NaiveDate>) -> Self {
+        Self {
+            symbol: symbol.into(),
+            start,
+            end,
+            metadata: HashMap::new(),
+        }
+    }
+
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct InstrumentStore {
+    inner: Arc<RwLock<HashMap<String, Instrument>>>,
+}
+
+impl InstrumentStore {
+    pub fn register(&self, instrument: Instrument) -> ProviderResult<()> {
+        let symbol = instrument.symbol.clone();
+        let mut guard = self
+            .inner
+            .write()
+            .map_err(|_| ProviderError::Instrument("lock poisoned".into()))?;
+        guard.insert(symbol.clone(), instrument);
+        log_event(
+            file!(),
+            "InstrumentStore",
+            "register",
+            "provider.instrument",
+            line!(),
+            &format!("Registered instrument {symbol}"),
+            None,
+            "none",
+            "POST",
+        );
+        Ok(())
+    }
+
+    pub fn get(&self, symbol: &str) -> ProviderResult<Option<Instrument>> {
+        let guard = self
+            .inner
+            .read()
+            .map_err(|_| ProviderError::Instrument("lock poisoned".into()))?;
+        Ok(guard.get(symbol).cloned())
+    }
+
+    pub fn all(&self) -> ProviderResult<Vec<Instrument>> {
+        let guard = self
+            .inner
+            .read()
+            .map_err(|_| ProviderError::Instrument("lock poisoned".into()))?;
+        Ok(guard.values().cloned().collect())
+    }
+}
+
+#[derive(Clone)]
+pub struct TradingCalendar {
+    sessions: Arc<RwLock<Vec<NaiveDate>>>,
+}
+
+impl TradingCalendar {
+    pub fn new(mut sessions: Vec<NaiveDate>) -> Self {
+        sessions.sort();
+        Self {
+            sessions: Arc::new(RwLock::new(sessions)),
+        }
+    }
+
+    pub fn contains(&self, date: &NaiveDate) -> ProviderResult<bool> {
+        let guard = self
+            .sessions
+            .read()
+            .map_err(|_| ProviderError::Calendar("lock poisoned".into()))?;
+        Ok(guard.binary_search(date).is_ok())
+    }
+
+    pub fn next(&self, date: &NaiveDate) -> ProviderResult<Option<NaiveDate>> {
+        let guard = self
+            .sessions
+            .read()
+            .map_err(|_| ProviderError::Calendar("lock poisoned".into()))?;
+        match guard.binary_search(date) {
+            Ok(idx) if idx + 1 < guard.len() => Ok(Some(guard[idx + 1])),
+            Ok(_) | Err(_) => guard
+                .iter()
+                .find(|session| *session > date)
+                .copied()
+                .map_or(Ok(None), |d| Ok(Some(d))),
+        }
+    }
+
+    pub fn previous(&self, date: &NaiveDate) -> ProviderResult<Option<NaiveDate>> {
+        let guard = self
+            .sessions
+            .read()
+            .map_err(|_| ProviderError::Calendar("lock poisoned".into()))?;
+        match guard.binary_search(date) {
+            Ok(idx) if idx > 0 => Ok(Some(guard[idx - 1])),
+            Ok(_) | Err(_) => guard
+                .iter()
+                .rev()
+                .find(|session| *session < date)
+                .copied()
+                .map_or(Ok(None), |d| Ok(Some(d))),
+        }
+    }
+
+    pub fn sessions(&self) -> ProviderResult<Vec<NaiveDate>> {
+        let guard = self
+            .sessions
+            .read()
+            .map_err(|_| ProviderError::Calendar("lock poisoned".into()))?;
+        Ok(guard.clone())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq)]
+pub struct FeatureKey {
+    pub instrument: String,
+    pub feature: String,
+    pub as_of: DateTime<Utc>,
+    pub horizon: Option<String>,
+}
+
+impl PartialEq for FeatureKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.instrument == other.instrument
+            && self.feature == other.feature
+            && self.as_of.timestamp_nanos_opt() == other.as_of.timestamp_nanos_opt()
+            && self.horizon == other.horizon
+    }
+}
+
+impl Hash for FeatureKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.instrument.hash(state);
+        self.feature.hash(state);
+        self.as_of
+            .timestamp_nanos_opt()
+            .unwrap_or_default()
+            .hash(state);
+        self.horizon.hash(state);
+    }
+}
+
+impl FeatureKey {
+    pub fn new<S: Into<String>>(instrument: S, feature: S, as_of: DateTime<Utc>) -> Self {
+        Self {
+            instrument: instrument.into(),
+            feature: feature.into(),
+            as_of,
+            horizon: None,
+        }
+    }
+
+    pub fn with_horizon(mut self, horizon: impl Into<String>) -> Self {
+        self.horizon = Some(horizon.into());
+        self
+    }
+}
+
+pub trait FeatureBackend: Send + Sync {
+    fn get(&self, key: &FeatureKey) -> ProviderResult<Option<DataFrame>>;
+    fn set(&self, key: FeatureKey, frame: DataFrame) -> ProviderResult<()>;
+    fn invalidate(&self, key: &FeatureKey) -> ProviderResult<()>;
+}
+
+#[derive(Default)]
+pub struct InMemoryFeatureBackend {
+    store: RwLock<HashMap<FeatureKey, DataFrame>>,
+}
+
+impl InMemoryFeatureBackend {
+    pub fn new() -> Self {
+        Self {
+            store: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl FeatureBackend for InMemoryFeatureBackend {
+    fn get(&self, key: &FeatureKey) -> ProviderResult<Option<DataFrame>> {
+        let guard = self
+            .store
+            .read()
+            .map_err(|_| ProviderError::FeatureBackend("lock poisoned".into()))?;
+        Ok(guard.get(key).cloned())
+    }
+
+    fn set(&self, key: FeatureKey, frame: DataFrame) -> ProviderResult<()> {
+        let mut guard = self
+            .store
+            .write()
+            .map_err(|_| ProviderError::FeatureBackend("lock poisoned".into()))?;
+        guard.insert(key.clone(), frame);
+        log_event(
+            file!(),
+            "InMemoryFeatureBackend",
+            "set",
+            "provider.feature",
+            line!(),
+            &format!("Stored feature {} for {}", key.feature, key.instrument),
+            None,
+            "post",
+            "PUT",
+        );
+        Ok(())
+    }
+
+    fn invalidate(&self, key: &FeatureKey) -> ProviderResult<()> {
+        let mut guard = self
+            .store
+            .write()
+            .map_err(|_| ProviderError::FeatureBackend("lock poisoned".into()))?;
+        guard.remove(key);
+        log_event(
+            file!(),
+            "InMemoryFeatureBackend",
+            "invalidate",
+            "provider.feature",
+            line!(),
+            &format!("Invalidated feature {} for {}", key.feature, key.instrument),
+            None,
+            "post",
+            "DELETE",
+        );
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct PitRecord {
+    pub instrument: String,
+    pub timestamp: DateTime<Utc>,
+    pub payload: DataFrame,
+}
+
+impl PitRecord {
+    pub fn new(
+        instrument: impl Into<String>,
+        timestamp: DateTime<Utc>,
+        payload: DataFrame,
+    ) -> Self {
+        Self {
+            instrument: instrument.into(),
+            timestamp,
+            payload,
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct PitStore {
+    records: Arc<RwLock<PitMap>>,
+}
+
+impl PitStore {
+    pub fn insert(&self, record: PitRecord) -> ProviderResult<()> {
+        let mut guard = self
+            .records
+            .write()
+            .map_err(|_| ProviderError::Pit("lock poisoned".into()))?;
+        let entry = guard.entry(record.instrument.clone()).or_default();
+        entry.insert(record.timestamp, record.payload.clone());
+        log_event(
+            file!(),
+            "PitStore",
+            "insert",
+            "provider.pit",
+            line!(),
+            &format!(
+                "Inserted PIT record for {} at {}",
+                record.instrument, record.timestamp
+            ),
+            None,
+            "post",
+            "PUT",
+        );
+        Ok(())
+    }
+
+    pub fn snapshot(
+        &self,
+        instrument: &str,
+        as_of: DateTime<Utc>,
+    ) -> ProviderResult<Option<DataFrame>> {
+        let guard = self
+            .records
+            .read()
+            .map_err(|_| ProviderError::Pit("lock poisoned".into()))?;
+        let Some(tree) = guard.get(instrument) else {
+            return Ok(None);
+        };
+        let mut iter = tree.range(..=as_of);
+        Ok(iter.next_back().map(|(_, frame)| frame.clone()))
+    }
+
+    pub fn range(
+        &self,
+        instrument: &str,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> ProviderResult<Vec<PitRecord>> {
+        if end < start {
+            return Err(ProviderError::Pit("end before start".into()));
+        }
+        let guard = self
+            .records
+            .read()
+            .map_err(|_| ProviderError::Pit("lock poisoned".into()))?;
+        let Some(tree) = guard.get(instrument) else {
+            return Ok(vec![]);
+        };
+        Ok(tree
+            .range(start..=end)
+            .map(|(timestamp, frame)| PitRecord {
+                instrument: instrument.to_string(),
+                timestamp: *timestamp,
+                payload: frame.clone(),
+            })
+            .collect())
+    }
+}
+
+#[derive(Clone)]
+pub struct DataProvider<B: FeatureBackend + 'static> {
+    calendar: TradingCalendar,
+    instruments: InstrumentStore,
+    feature_backend: Arc<B>,
+    pit_store: PitStore,
+}
+
+impl<B: FeatureBackend + 'static> DataProvider<B> {
+    pub fn new(calendar: TradingCalendar, backend: Arc<B>) -> Self {
+        Self {
+            calendar,
+            instruments: InstrumentStore::default(),
+            feature_backend: backend,
+            pit_store: PitStore::default(),
+        }
+    }
+
+    pub fn with_components(
+        calendar: TradingCalendar,
+        instruments: InstrumentStore,
+        backend: Arc<B>,
+        pit_store: PitStore,
+    ) -> Self {
+        Self {
+            calendar,
+            instruments,
+            feature_backend: backend,
+            pit_store,
+        }
+    }
+
+    pub fn calendar(&self) -> &TradingCalendar {
+        &self.calendar
+    }
+
+    pub fn instruments(&self) -> &InstrumentStore {
+        &self.instruments
+    }
+
+    pub fn pit_store(&self) -> &PitStore {
+        &self.pit_store
+    }
+
+    pub fn backend(&self) -> &Arc<B> {
+        &self.feature_backend
+    }
+
+    pub fn store_instrument(&self, instrument: Instrument) -> ProviderResult<()> {
+        self.instruments.register(instrument)
+    }
+
+    pub fn load_feature(&self, key: &FeatureKey) -> ProviderResult<Option<DataFrame>> {
+        self.feature_backend.get(key)
+    }
+
+    pub fn store_feature(&self, key: FeatureKey, frame: DataFrame) -> ProviderResult<()> {
+        self.feature_backend.set(key, frame)
+    }
+
+    pub fn invalidate_feature(&self, key: &FeatureKey) -> ProviderResult<()> {
+        self.feature_backend.invalidate(key)
+    }
+
+    pub fn store_pit(&self, record: PitRecord) -> ProviderResult<()> {
+        self.pit_store.insert(record)
+    }
+
+    pub fn pit_snapshot(
+        &self,
+        instrument: &str,
+        as_of: DateTime<Utc>,
+    ) -> ProviderResult<Option<DataFrame>> {
+        self.pit_store.snapshot(instrument, as_of)
+    }
+}
+
+pub type DefaultDataProvider = DataProvider<InMemoryFeatureBackend>;
+
+impl DefaultDataProvider {
+    pub fn with_calendar(calendar: TradingCalendar) -> Self {
+        Self::new(calendar, Arc::new(InMemoryFeatureBackend::new()))
+    }
+}

--- a/qliber/task.md
+++ b/qliber/task.md
@@ -23,7 +23,7 @@
 - [x] Port portfolio analytics (position valuation, return series, annual metrics) to Rust
 - [x] Expand regression tests to cover the new portfolio analytics surface
 - [x] Document the portfolio module additions in the README
-- [ ] Port Qlib's provider infrastructure (calendars, instruments, feature caching/backends, and PIT storage) into Rust's dataset layer to match `qlib.data.data` and `qlib.data.storage` capabilities
+- [x] Port Qlib's provider infrastructure (calendars, instruments, feature caching/backends, and PIT storage) into Rust's dataset layer to match `qlib.data.data` and `qlib.data.storage` capabilities
 - [ ] Implement the configurable dataset handler/loader/processor pipeline (DataHandler, DataLoader, Processor stacks) to mirror `qlib.data.dataset` semantics for feature/label management
 - [ ] Recreate the expression operator engine (Operators, rolling/expanding stats, percentile utilities) covering the breadth of `qlib.data.ops`
 - [ ] Add remote data server compatibility, including the socket.io client protocol exposed in `qlib.data.client`, for distributed data access

--- a/qliber/tests/provider.rs
+++ b/qliber/tests/provider.rs
@@ -1,0 +1,164 @@
+use std::sync::{Arc, Once};
+
+use chrono::{NaiveDate, TimeZone, Utc};
+use polars::prelude::*;
+use qliber::{
+    DataProvider, FeatureBackend, FeatureKey, InMemoryFeatureBackend, Instrument, ProviderResult,
+    TradingCalendar,
+};
+
+static INIT: Once = Once::new();
+
+fn init_logging() {
+    INIT.call_once(|| {
+        let _ = qliber::logging::init_logging();
+    });
+}
+
+fn sample_calendar() -> TradingCalendar {
+    TradingCalendar::new(vec![
+        NaiveDate::from_ymd_opt(2024, 1, 2).unwrap(),
+        NaiveDate::from_ymd_opt(2024, 1, 3).unwrap(),
+        NaiveDate::from_ymd_opt(2024, 1, 4).unwrap(),
+    ])
+}
+
+fn sample_frame() -> DataFrame {
+    df!(
+        "value" => &[1.0, 2.0, 3.0],
+        "timestamp" => &[
+            "2024-01-02T00:00:00Z",
+            "2024-01-03T00:00:00Z",
+            "2024-01-04T00:00:00Z",
+        ]
+    )
+    .expect("frame construction")
+}
+
+#[test]
+fn calendar_navigation() -> ProviderResult<()> {
+    init_logging();
+    let calendar = sample_calendar();
+    assert!(calendar.contains(&NaiveDate::from_ymd_opt(2024, 1, 3).unwrap())?);
+    assert!(!calendar.contains(&NaiveDate::from_ymd_opt(2024, 1, 5).unwrap())?);
+
+    assert_eq!(
+        calendar.next(&NaiveDate::from_ymd_opt(2024, 1, 2).unwrap())?,
+        Some(NaiveDate::from_ymd_opt(2024, 1, 3).unwrap())
+    );
+    assert_eq!(
+        calendar.previous(&NaiveDate::from_ymd_opt(2024, 1, 3).unwrap())?,
+        Some(NaiveDate::from_ymd_opt(2024, 1, 2).unwrap())
+    );
+    Ok(())
+}
+
+#[test]
+fn instrument_store_register_and_get() -> ProviderResult<()> {
+    init_logging();
+    let store = qliber::InstrumentStore::default();
+    let instrument = Instrument::new(
+        "SH600000",
+        NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+        None,
+    )
+    .with_metadata("exchange", "SSE");
+    store.register(instrument.clone())?;
+    let fetched = store.get("SH600000")?.expect("instrument present");
+    assert_eq!(fetched.symbol, instrument.symbol);
+    assert_eq!(fetched.metadata.get("exchange"), Some(&"SSE".to_string()));
+    Ok(())
+}
+
+#[test]
+fn feature_backend_roundtrip() -> ProviderResult<()> {
+    init_logging();
+    let backend = InMemoryFeatureBackend::new();
+    let frame = sample_frame();
+    let key = FeatureKey::new(
+        "SH600000",
+        "close",
+        Utc.with_ymd_and_hms(2024, 1, 4, 0, 0, 0).unwrap(),
+    );
+    backend.set(key.clone(), frame.clone())?;
+    let loaded = backend.get(&key)?.expect("feature present");
+    assert_eq!(loaded.shape(), frame.shape());
+    backend.invalidate(&key)?;
+    assert!(backend.get(&key)?.is_none());
+    Ok(())
+}
+
+#[test]
+fn pit_store_snapshot_range() -> ProviderResult<()> {
+    init_logging();
+    let store = qliber::PitStore::default();
+    let frame = sample_frame();
+    store.insert(qliber::PitRecord::new(
+        "SH600000",
+        Utc.with_ymd_and_hms(2024, 1, 3, 0, 0, 0).unwrap(),
+        frame.clone(),
+    ))?;
+    store.insert(qliber::PitRecord::new(
+        "SH600000",
+        Utc.with_ymd_and_hms(2024, 1, 4, 0, 0, 0).unwrap(),
+        frame.clone(),
+    ))?;
+    let snapshot = store
+        .snapshot(
+            "SH600000",
+            Utc.with_ymd_and_hms(2024, 1, 4, 0, 0, 0).unwrap(),
+        )?
+        .expect("snapshot available");
+    assert_eq!(snapshot.shape(), frame.shape());
+    let range = store.range(
+        "SH600000",
+        Utc.with_ymd_and_hms(2024, 1, 3, 0, 0, 0).unwrap(),
+        Utc.with_ymd_and_hms(2024, 1, 4, 0, 0, 0).unwrap(),
+    )?;
+    assert_eq!(range.len(), 2);
+    Ok(())
+}
+
+#[test]
+fn data_provider_end_to_end() -> ProviderResult<()> {
+    init_logging();
+    let calendar = sample_calendar();
+    let backend = Arc::new(InMemoryFeatureBackend::new());
+    let provider = DataProvider::new(calendar.clone(), backend);
+    provider.store_instrument(Instrument::new(
+        "SH600000",
+        NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+        None,
+    ))?;
+
+    let key = FeatureKey::new(
+        "SH600000",
+        "close",
+        Utc.with_ymd_and_hms(2024, 1, 4, 0, 0, 0).unwrap(),
+    );
+    let frame = sample_frame();
+    provider.store_feature(key.clone(), frame.clone())?;
+    let fetched = provider
+        .load_feature(&key)?
+        .expect("feature present via provider");
+    assert_eq!(fetched.shape(), frame.shape());
+
+    provider.store_pit(qliber::PitRecord::new(
+        "SH600000",
+        Utc.with_ymd_and_hms(2024, 1, 4, 0, 0, 0).unwrap(),
+        frame.clone(),
+    ))?;
+    let pit = provider.pit_snapshot(
+        "SH600000",
+        Utc.with_ymd_and_hms(2024, 1, 4, 0, 0, 0).unwrap(),
+    )?;
+    assert!(pit.is_some());
+
+    assert!(
+        provider
+            .calendar()
+            .contains(&NaiveDate::from_ymd_opt(2024, 1, 2).unwrap())?
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a `provider` module with trading calendars, instrument registry, feature caching, and PIT storage primitives
- wire the provider exports into the crate surface and document the new capabilities
- introduce focused tests validating calendar navigation, caching, PIT snapshots, and provider orchestration

## Testing
- cargo fmt
- cargo clippy -- -D warnings
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e8601fde10832bb1c0a2ee09b693a5