### PR TITLE
Add qlib.config parity module and integrate cache clearing

### DIFF
--- a/qliber/README.md
+++ b/qliber/README.md
@@ -59,7 +59,7 @@ use qliber::{
 };
 
 fn main() -> anyhow::Result<()> {
-    qliber::logging::init_logging()?;
+    qliber::init(qliber::DefaultConfig::Client, qliber::InitOptions::default())?;
     let market = MarketData::from_csv("data/market.csv")?;
     let filtered = market.filter_date_range(
         "timestamp",
@@ -147,6 +147,21 @@ fn main() -> anyhow::Result<()> {
 The `risk_analysis` and `indicator_analysis_with_method` helpers accept the same string-based
 options as Qlib's Python API, making it straightforward to port workflows that rely on
 `mode="sum"/"product"` or indicator weighting strings without changing call sites.
+
+### Configuration
+
+`qliber::init` mirrors the behavior of `qlib.config` and `qlib.init` by providing global
+configuration, logging initialization, and cache management:
+
+- Select a `DefaultConfig` (`Client` or `Server`) and override parameters with
+  `InitOptions` (provider URIs, mount paths, logging level/filter, cache settings, and
+  computation kernels).
+- Control the geographic preset via the exported `REG_CN`, `REG_US`, and `REG_TW`
+  region constants.
+- Automatically clear registered in-memory feature caches on initialization, matching the
+  Python `clear_mem_cache` semantics.
+- Query resolved provider and mount paths through `qliber::config_snapshot()` or by using
+  `qliber::with_data_path` to inspect file-system mappings.
 
 ## Development
 

--- a/qliber/src/bin/qrun.rs
+++ b/qliber/src/bin/qrun.rs
@@ -6,9 +6,8 @@ use anyhow::Result;
 use polars::prelude::*;
 use serde::Deserialize;
 
-use qliber::logging;
 use qliber::workflow::ExperimentManager;
-use qliber::{MeanModel, Trainer};
+use qliber::{DefaultConfig, InitOptions, MeanModel, Trainer, init};
 
 #[derive(Debug, Deserialize)]
 struct Config {
@@ -18,7 +17,7 @@ struct Config {
 }
 
 fn main() -> Result<()> {
-    logging::init_logging()?;
+    init(DefaultConfig::Client, InitOptions::default())?;
     let args: Vec<String> = env::args().collect();
     let mut config_path: Option<PathBuf> = None;
     let mut idx = 1;

--- a/qliber/src/config.rs
+++ b/qliber/src/config.rs
@@ -1,0 +1,595 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{OnceLock, RwLock};
+use std::thread;
+
+use anyhow::{Context, Result, anyhow};
+use tracing::Level;
+
+use crate::logging::{init_logging_with_filter, log_event};
+use crate::provider::clear_registered_caches;
+
+const DEFAULT_FREQ: &str = "__DEFAULT_FREQ";
+
+/// Region identifiers mirroring qlib's constants.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Region {
+    China,
+    UnitedStates,
+    Taiwan,
+}
+
+impl Region {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Region::China => "cn",
+            Region::UnitedStates => "us",
+            Region::Taiwan => "tw",
+        }
+    }
+}
+
+/// Default configuration templates that mirror qlib's `client` and `server` modes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum DefaultConfig {
+    #[default]
+    Client,
+    Server,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LoggingSettings {
+    pub level: Level,
+    pub filter: Option<String>,
+}
+
+impl Default for LoggingSettings {
+    fn default() -> Self {
+        Self {
+            level: Level::INFO,
+            filter: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConfigState {
+    mode: DefaultConfig,
+    region: Region,
+    provider_uri: HashMap<String, PathBuf>,
+    mount_path: HashMap<String, PathBuf>,
+    auto_mount: bool,
+    logging: LoggingSettings,
+    expression_cache: Option<String>,
+    dataset_cache: Option<String>,
+    kernels: usize,
+}
+
+impl ConfigState {
+    fn data_path_manager(&self) -> DataPathManager {
+        DataPathManager {
+            provider_uri: self.provider_uri.clone(),
+            mount_path: self.mount_path.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ConfigTemplate {
+    provider_uri: HashMap<String, PathBuf>,
+    mount_path: HashMap<String, PathBuf>,
+    auto_mount: bool,
+    logging: LoggingSettings,
+    expression_cache: Option<String>,
+    dataset_cache: Option<String>,
+    kernels: usize,
+}
+
+impl ConfigTemplate {
+    fn new_default(provider: &str, auto_mount: bool) -> Self {
+        let provider_path = PathBuf::from(provider);
+        let mut provider_uri = HashMap::new();
+        provider_uri.insert(DEFAULT_FREQ.to_string(), provider_path.clone());
+
+        let mut mount_path = HashMap::new();
+        mount_path.insert(DEFAULT_FREQ.to_string(), provider_path.clone());
+
+        Self {
+            provider_uri,
+            mount_path,
+            auto_mount,
+            logging: LoggingSettings::default(),
+            expression_cache: None,
+            dataset_cache: None,
+            kernels: compute_default_kernels(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ConfigSnapshot {
+    pub mode: DefaultConfig,
+    pub region: Region,
+    pub provider_uri: HashMap<String, PathBuf>,
+    pub mount_path: HashMap<String, PathBuf>,
+    pub auto_mount: bool,
+    pub logging: LoggingSettings,
+    pub expression_cache: Option<String>,
+    pub dataset_cache: Option<String>,
+    pub kernels: usize,
+    pub registered: bool,
+}
+
+#[derive(Debug)]
+pub struct QlibConfig {
+    state: ConfigState,
+    client_template: ConfigTemplate,
+    server_template: ConfigTemplate,
+    registered: bool,
+}
+
+impl QlibConfig {
+    fn new() -> Self {
+        let client_template = ConfigTemplate::new_default("~/.qlib/qlib_data/cn_data", false);
+        let server_template = ConfigTemplate::new_default("~/.qlib/qlib_data/cn_data", true);
+
+        Self {
+            state: ConfigState {
+                mode: DefaultConfig::Client,
+                region: Region::China,
+                provider_uri: client_template.provider_uri.clone(),
+                mount_path: client_template.mount_path.clone(),
+                auto_mount: client_template.auto_mount,
+                logging: client_template.logging.clone(),
+                expression_cache: client_template.expression_cache.clone(),
+                dataset_cache: client_template.dataset_cache.clone(),
+                kernels: client_template.kernels,
+            },
+            client_template,
+            server_template,
+            registered: false,
+        }
+    }
+
+    fn set(&mut self, mode: DefaultConfig, options: &InitOptions) -> Result<()> {
+        self.registered = false;
+        self.apply_mode(mode);
+        self.apply_region(options.region.unwrap_or(self.state.region));
+        self.apply_overrides(options)?;
+        self.resolve_paths()?;
+        Ok(())
+    }
+
+    fn apply_mode(&mut self, mode: DefaultConfig) {
+        self.state.mode = mode;
+        let template = match mode {
+            DefaultConfig::Client => &self.client_template,
+            DefaultConfig::Server => &self.server_template,
+        };
+
+        self.state.provider_uri = template.provider_uri.clone();
+        self.state.mount_path = template.mount_path.clone();
+        self.state.auto_mount = template.auto_mount;
+        self.state.logging = template.logging.clone();
+        self.state.expression_cache = template.expression_cache.clone();
+        self.state.dataset_cache = template.dataset_cache.clone();
+        self.state.kernels = template.kernels;
+    }
+
+    fn apply_region(&mut self, region: Region) {
+        self.state.region = region;
+    }
+
+    fn apply_overrides(&mut self, options: &InitOptions) -> Result<()> {
+        if let Some(ref provider_uri) = options.provider_uri {
+            self.state.provider_uri = normalize_provider_map(provider_uri);
+        }
+
+        if let Some(ref mount_path) = options.mount_path {
+            self.state.mount_path = normalize_mount_map(mount_path);
+        }
+
+        if let Some(auto_mount) = options.auto_mount {
+            self.state.auto_mount = auto_mount;
+        }
+
+        if let Some(level) = options.logging_level {
+            self.state.logging.level = level;
+        }
+
+        if let Some(ref filter) = options.logging_filter {
+            self.state.logging.filter = Some(filter.clone());
+        }
+
+        if let Some(region) = options.region {
+            self.apply_region(region);
+        }
+
+        if let Some(value) = &options.expression_cache {
+            self.state.expression_cache = value.clone();
+        }
+
+        if let Some(value) = &options.dataset_cache {
+            self.state.dataset_cache = value.clone();
+        }
+
+        if let Some(kernels) = options.kernels {
+            self.state.kernels = kernels.max(1);
+        }
+
+        Ok(())
+    }
+
+    fn resolve_paths(&mut self) -> Result<()> {
+        self.state.provider_uri = self
+            .state
+            .provider_uri
+            .iter()
+            .map(|(freq, path)| (freq.clone(), expand_user(path)))
+            .collect();
+
+        let mut resolved_mount = HashMap::new();
+        if self.state.mount_path.is_empty() {
+            for (freq, path) in &self.state.provider_uri {
+                resolved_mount.insert(freq.clone(), path.clone());
+            }
+        } else {
+            for (freq, path) in &self.state.mount_path {
+                resolved_mount.insert(freq.clone(), expand_user(path));
+            }
+        }
+
+        for freq in self.state.provider_uri.keys() {
+            resolved_mount
+                .entry(freq.clone())
+                .or_insert_with(|| self.state.provider_uri[freq].clone());
+        }
+
+        self.state.mount_path = resolved_mount;
+
+        for uri in self.state.provider_uri.values() {
+            let uri_type = DataPathManager::get_uri_type(uri);
+            if matches!(uri_type, UriType::Local) && !uri.exists() && self.state.auto_mount {
+                std::fs::create_dir_all(uri).with_context(|| {
+                    format!("failed to create provider uri directory {}", uri.display())
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn register(&mut self) {
+        self.registered = true;
+        log_event(
+            file!(),
+            "QlibConfig",
+            "register",
+            "config",
+            line!(),
+            &format!(
+                "qlib initialized in {:?} mode for region {}",
+                self.state.mode,
+                self.state.region.as_str()
+            ),
+            None,
+            "post",
+            "POST",
+        );
+    }
+
+    fn logging(&self) -> &LoggingSettings {
+        &self.state.logging
+    }
+
+    fn snapshot(&self) -> ConfigSnapshot {
+        ConfigSnapshot {
+            mode: self.state.mode,
+            region: self.state.region,
+            provider_uri: self.state.provider_uri.clone(),
+            mount_path: self.state.mount_path.clone(),
+            auto_mount: self.state.auto_mount,
+            logging: self.state.logging.clone(),
+            expression_cache: self.state.expression_cache.clone(),
+            dataset_cache: self.state.dataset_cache.clone(),
+            kernels: self.state.kernels,
+            registered: self.registered,
+        }
+    }
+
+    fn registered(&self) -> bool {
+        self.registered
+    }
+
+    fn data_path_manager(&self) -> DataPathManager {
+        self.state.data_path_manager()
+    }
+
+    fn provider_entries(&self) -> Vec<(String, PathBuf, UriType, PathBuf)> {
+        self.state
+            .provider_uri
+            .iter()
+            .map(|(freq, uri)| {
+                let uri_type = DataPathManager::get_uri_type(uri);
+                let mount = self
+                    .state
+                    .mount_path
+                    .get(freq)
+                    .cloned()
+                    .unwrap_or_else(|| uri.clone());
+                (freq.clone(), uri.clone(), uri_type, mount)
+            })
+            .collect()
+    }
+
+    fn auto_mount(&self) -> bool {
+        self.state.auto_mount
+    }
+}
+
+fn compute_default_kernels() -> usize {
+    let available = thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    available.saturating_sub(2).max(1)
+}
+
+fn normalize_provider_map(map: &HashMap<String, PathBuf>) -> HashMap<String, PathBuf> {
+    if map.is_empty() {
+        return HashMap::from([(DEFAULT_FREQ.to_string(), PathBuf::from("."))]);
+    }
+
+    let mut normalized = HashMap::new();
+    for (freq, path) in map {
+        normalized.insert(freq.clone(), path.clone());
+    }
+
+    if !normalized.contains_key(DEFAULT_FREQ)
+        && let Some((_freq, path)) = normalized.iter().next()
+    {
+        normalized.insert(DEFAULT_FREQ.to_string(), path.clone());
+    }
+
+    normalized
+}
+
+fn normalize_mount_map(map: &HashMap<String, PathBuf>) -> HashMap<String, PathBuf> {
+    if map.is_empty() {
+        return HashMap::new();
+    }
+
+    let mut normalized = HashMap::new();
+    for (freq, path) in map {
+        normalized.insert(freq.clone(), path.clone());
+    }
+
+    normalized
+}
+
+fn expand_user(path: &Path) -> PathBuf {
+    let path_str = path.to_string_lossy();
+    if path_str == "~" {
+        return home_dir().unwrap_or_else(|| PathBuf::from("~"));
+    }
+
+    if let Some(stripped) = path_str.strip_prefix("~/")
+        && let Some(home) = home_dir()
+    {
+        return home.join(stripped);
+    }
+
+    PathBuf::from(path)
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+#[derive(Clone, Debug)]
+pub struct DataPathManager {
+    provider_uri: HashMap<String, PathBuf>,
+    mount_path: HashMap<String, PathBuf>,
+}
+
+impl DataPathManager {
+    pub fn get_data_uri(&self, freq: Option<&str>) -> PathBuf {
+        let target_freq = freq.unwrap_or(DEFAULT_FREQ);
+        if let Some(path) = self.provider_uri.get(target_freq) {
+            return path.clone();
+        }
+        self.provider_uri
+            .get(DEFAULT_FREQ)
+            .cloned()
+            .unwrap_or_else(|| PathBuf::from("."))
+    }
+
+    fn get_uri_type(path: &Path) -> UriType {
+        let display = path.to_string_lossy();
+        if is_windows_path(&display) {
+            return UriType::Local;
+        }
+
+        if display.contains(':') {
+            return UriType::Nfs;
+        }
+
+        UriType::Local
+    }
+
+    pub fn mount_path(&self, freq: &str) -> Option<PathBuf> {
+        self.mount_path.get(freq).cloned()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum UriType {
+    Local,
+    Nfs,
+}
+
+fn is_windows_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    if bytes.len() < 2 {
+        return false;
+    }
+    bytes[1] == b':' && bytes[0].is_ascii_alphabetic()
+}
+
+#[derive(Clone, Debug)]
+pub struct InitOptions {
+    pub provider_uri: Option<HashMap<String, PathBuf>>,
+    pub mount_path: Option<HashMap<String, PathBuf>>,
+    pub auto_mount: Option<bool>,
+    pub logging_level: Option<Level>,
+    pub logging_filter: Option<String>,
+    pub region: Option<Region>,
+    pub expression_cache: Option<Option<String>>,
+    pub dataset_cache: Option<Option<String>>,
+    pub kernels: Option<usize>,
+    pub skip_if_registered: bool,
+    pub clear_mem_cache: bool,
+}
+
+impl InitOptions {
+    pub fn without_cache_clear() -> Self {
+        Self {
+            clear_mem_cache: false,
+            ..Self::default()
+        }
+    }
+}
+
+impl Default for InitOptions {
+    fn default() -> Self {
+        Self {
+            provider_uri: None,
+            mount_path: None,
+            auto_mount: None,
+            logging_level: None,
+            logging_filter: None,
+            region: None,
+            expression_cache: None,
+            dataset_cache: None,
+            kernels: None,
+            skip_if_registered: false,
+            clear_mem_cache: true,
+        }
+    }
+}
+
+static GLOBAL_CONFIG: OnceLock<RwLock<QlibConfig>> = OnceLock::new();
+
+fn config_lock() -> &'static RwLock<QlibConfig> {
+    GLOBAL_CONFIG.get_or_init(|| RwLock::new(QlibConfig::new()))
+}
+
+pub fn init(mode: DefaultConfig, options: InitOptions) -> Result<()> {
+    let lock = config_lock();
+    let mut guard = lock
+        .write()
+        .map_err(|_| anyhow!("qlib config lock poisoned"))?;
+
+    if options.skip_if_registered && guard.registered() {
+        log_event(
+            file!(),
+            "QlibConfig",
+            "init_skip",
+            "config",
+            line!(),
+            "Initialization skipped because configuration is already registered",
+            None,
+            "none",
+            "GET",
+        );
+        return Ok(());
+    }
+
+    if options.clear_mem_cache {
+        clear_registered_caches().map_err(|err| anyhow!(err))?;
+    }
+
+    guard.set(mode, &options)?;
+    let logging = guard.logging().clone();
+    let provider_entries = guard.provider_entries();
+    let auto_mount = guard.auto_mount();
+    init_logging_with_filter(logging.filter.as_deref(), Some(logging.level))?;
+    for (freq, uri, uri_type, mount) in provider_entries {
+        match uri_type {
+            UriType::Local => {
+                let message = if uri.exists() {
+                    format!("Provider URI for {freq} resolved to {}", uri.display())
+                } else if auto_mount {
+                    format!(
+                        "Provider URI for {freq} created at {} due to auto_mount",
+                        uri.display()
+                    )
+                } else {
+                    format!(
+                        "Provider URI for {freq} missing at {} (auto_mount disabled)",
+                        uri.display()
+                    )
+                };
+                log_event(
+                    file!(),
+                    "QlibConfig",
+                    "provider_uri",
+                    "config.provider",
+                    line!(),
+                    &message,
+                    None,
+                    "none",
+                    "GET",
+                );
+            }
+            UriType::Nfs => {
+                log_event(
+                    file!(),
+                    "QlibConfig",
+                    "provider_uri",
+                    "config.provider",
+                    line!(),
+                    &format!(
+                        "NFS provider URI for {freq} resolved to {} with mount {}",
+                        uri.display(),
+                        mount.display()
+                    ),
+                    None,
+                    "none",
+                    "GET",
+                );
+            }
+        }
+    }
+    guard.register();
+
+    Ok(())
+}
+
+pub fn config_snapshot() -> Option<ConfigSnapshot> {
+    let lock = GLOBAL_CONFIG.get()?;
+    let guard = lock.read().ok()?;
+    Some(guard.snapshot())
+}
+
+pub fn with_data_path<F, R>(func: F) -> Result<R>
+where
+    F: FnOnce(&DataPathManager) -> R,
+{
+    let lock = config_lock();
+    let guard = lock
+        .read()
+        .map_err(|_| anyhow!("qlib config lock poisoned"))?;
+    Ok(func(&guard.data_path_manager()))
+}
+
+pub const REG_CN: Region = Region::China;
+pub const REG_US: Region = Region::UnitedStates;
+pub const REG_TW: Region = Region::Taiwan;
+
+pub fn reset_for_tests() {
+    if let Some(lock) = GLOBAL_CONFIG.get()
+        && let Ok(mut guard) = lock.write()
+    {
+        *guard = QlibConfig::new();
+    }
+}

--- a/qliber/src/lib.rs
+++ b/qliber/src/lib.rs
@@ -3,6 +3,7 @@
 //! and structured logging tailored for quantitative research pipelines.
 
 pub mod backtest;
+pub mod config;
 pub mod contrib;
 pub mod dataset;
 pub mod features;
@@ -20,6 +21,10 @@ pub use backtest::{
     BacktestError, BacktestReport, BacktestResult, Backtester, ExecutionReport, MarketEvent,
     MarketSnapshot, OrderSignal, PipelineStrategy, RLStrategy, SignalInterpreter, SimpleExecutor,
     StaticRLStrategy, Strategy, ThresholdInterpreter,
+};
+pub use config::{
+    ConfigSnapshot, DefaultConfig, InitOptions, REG_CN, REG_TW, REG_US, Region, config_snapshot,
+    init, with_data_path,
 };
 pub use contrib::{Alpha158Processor, Alpha360Processor};
 pub use dataset::{

--- a/qliber/src/logging.rs
+++ b/qliber/src/logging.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
-use tracing::info;
+use tracing::{Level, info};
 use tracing_subscriber::{EnvFilter, fmt};
 
 use crate::Result;
@@ -27,15 +27,29 @@ pub struct LogEvent<'a> {
     pub derived: &'a str,
 }
 
-/// Initialize tracing subscriber emitting JSON records that follow the required schema.
+/// Initialize tracing subscriber emitting JSON records with the configured filter.
 ///
 /// Calling this function multiple times is safe; only the first invocation installs the
 /// subscriber.
 pub fn init_logging() -> Result<()> {
-    let result = SUBSCRIBER.get_or_init(|| {
-        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    init_logging_with_filter(None, None)
+}
+
+/// Initialize tracing subscriber with an explicit filter string or level override.
+pub fn init_logging_with_filter(filter: Option<&str>, level: Option<Level>) -> Result<()> {
+    let filter_string = filter
+        .map(|value| value.to_string())
+        .or_else(|| level.map(|lvl| lvl.to_string().to_lowercase()));
+
+    let result = SUBSCRIBER.get_or_init(move || {
+        let env_filter = if let Some(ref pattern) = filter_string {
+            EnvFilter::try_new(pattern.clone()).map_err(|error| error.to_string())?
+        } else {
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
+        };
+
         fmt()
-            .with_env_filter(filter)
+            .with_env_filter(env_filter)
             .json()
             .with_current_span(false)
             .with_span_list(false)

--- a/qliber/src/provider.rs
+++ b/qliber/src/provider.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 
 use chrono::{DateTime, NaiveDate, Utc};
 use polars::prelude::*;
@@ -8,6 +8,100 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::logging::log_event;
+
+type CacheClearer = Arc<dyn Fn() -> ProviderResult<()> + Send + Sync>;
+
+static FEATURE_CACHE_REGISTRY: OnceLock<RwLock<Vec<CacheClearer>>> = OnceLock::new();
+
+fn cache_registry() -> &'static RwLock<Vec<CacheClearer>> {
+    FEATURE_CACHE_REGISTRY.get_or_init(|| RwLock::new(Vec::new()))
+}
+
+fn register_cache_clearer(clearer: CacheClearer) {
+    match cache_registry().write() {
+        Ok(mut guard) => guard.push(clearer),
+        Err(_) => {
+            log_event(
+                file!(),
+                "CacheRegistry",
+                "register",
+                "provider.cache",
+                line!(),
+                "Failed to register cache clearer due to poisoned lock",
+                Some("lock poisoned"),
+                "none",
+                "POST",
+            );
+        }
+    }
+}
+
+pub fn clear_registered_caches() -> ProviderResult<()> {
+    let clearers = match cache_registry().read() {
+        Ok(guard) => guard.iter().cloned().collect::<Vec<_>>(),
+        Err(_) => {
+            let message = "cache registry lock poisoned".to_string();
+            log_event(
+                file!(),
+                "CacheRegistry",
+                "clear",
+                "provider.cache",
+                line!(),
+                &message,
+                Some(&message),
+                "none",
+                "DELETE",
+            );
+            return Err(ProviderError::FeatureBackend(message));
+        }
+    };
+
+    let mut errors = Vec::new();
+    for clearer in &clearers {
+        if let Err(err) = clearer() {
+            errors.push(err);
+        }
+    }
+
+    if errors.is_empty() {
+        log_event(
+            file!(),
+            "CacheRegistry",
+            "clear",
+            "provider.cache",
+            line!(),
+            &format!("Cleared {} registered feature caches", clearers.len()),
+            None,
+            "post",
+            "DELETE",
+        );
+        Ok(())
+    } else {
+        let message = errors
+            .into_iter()
+            .map(|err| err.to_string())
+            .collect::<Vec<_>>()
+            .join("; ");
+        log_event(
+            file!(),
+            "CacheRegistry",
+            "clear",
+            "provider.cache",
+            line!(),
+            &message,
+            Some(&message),
+            "none",
+            "DELETE",
+        );
+        Err(ProviderError::FeatureBackend(message))
+    }
+}
+
+fn register_backend_for_clearing<B: FeatureBackend + 'static>(backend: &Arc<B>) {
+    let backend = Arc::clone(backend);
+    let clearer: CacheClearer = Arc::new(move || backend.clear_all());
+    register_cache_clearer(clearer);
+}
 
 type PitMap = HashMap<String, BTreeMap<DateTime<Utc>, DataFrame>>;
 
@@ -204,6 +298,7 @@ pub trait FeatureBackend: Send + Sync {
     fn get(&self, key: &FeatureKey) -> ProviderResult<Option<DataFrame>>;
     fn set(&self, key: FeatureKey, frame: DataFrame) -> ProviderResult<()>;
     fn invalidate(&self, key: &FeatureKey) -> ProviderResult<()>;
+    fn clear_all(&self) -> ProviderResult<()>;
 }
 
 #[derive(Default)]
@@ -261,6 +356,27 @@ impl FeatureBackend for InMemoryFeatureBackend {
             "provider.feature",
             line!(),
             &format!("Invalidated feature {} for {}", key.feature, key.instrument),
+            None,
+            "post",
+            "DELETE",
+        );
+        Ok(())
+    }
+
+    fn clear_all(&self) -> ProviderResult<()> {
+        let mut guard = self
+            .store
+            .write()
+            .map_err(|_| ProviderError::FeatureBackend("lock poisoned".into()))?;
+        let cleared = guard.len();
+        guard.clear();
+        log_event(
+            file!(),
+            "InMemoryFeatureBackend",
+            "clear_all",
+            "provider.feature",
+            line!(),
+            &format!("Cleared {cleared} cached feature frames"),
             None,
             "post",
             "DELETE",
@@ -373,6 +489,7 @@ pub struct DataProvider<B: FeatureBackend + 'static> {
 
 impl<B: FeatureBackend + 'static> DataProvider<B> {
     pub fn new(calendar: TradingCalendar, backend: Arc<B>) -> Self {
+        register_backend_for_clearing(&backend);
         Self {
             calendar,
             instruments: InstrumentStore::default(),
@@ -387,6 +504,7 @@ impl<B: FeatureBackend + 'static> DataProvider<B> {
         backend: Arc<B>,
         pit_store: PitStore,
     ) -> Self {
+        register_backend_for_clearing(&backend);
         Self {
             calendar,
             instruments,

--- a/qliber/task.md
+++ b/qliber/task.md
@@ -35,3 +35,6 @@
 - [x] Ship CLI tooling (`qrun`, data preparation helpers) to orchestrate workflows like the Python `qlib.cli` package
 - [x] Reimplement the contrib data handlers and factor templates (e.g., Alpha158/Alpha360 processors) from `qlib.contrib`
 - [x] Add integration coverage for the `qrun` CLI training workflow
+- [x] Port qlib.config initialization semantics into Rust (global config + init entrypoint)
+- [x] Register cache clearing hooks to honor clear_mem_cache parity
+- [x] Document the configuration API and add regression tests for initialization behavior

--- a/qliber/tests/config.rs
+++ b/qliber/tests/config.rs
@@ -1,0 +1,58 @@
+use chrono::{NaiveDate, TimeZone, Utc};
+use polars::prelude::*;
+use tracing::Level;
+
+use qliber::config::reset_for_tests;
+use qliber::provider::{DefaultDataProvider, FeatureKey, TradingCalendar};
+use qliber::{DefaultConfig, InitOptions, Region, config_snapshot, init};
+
+#[test]
+fn init_establishes_client_defaults() -> anyhow::Result<()> {
+    reset_for_tests();
+    init(DefaultConfig::Client, InitOptions::default())?;
+    let snapshot = config_snapshot().expect("config snapshot available");
+    assert_eq!(snapshot.mode, DefaultConfig::Client);
+    assert_eq!(snapshot.region, Region::China);
+    assert!(snapshot.registered);
+    Ok(())
+}
+
+#[test]
+fn init_respects_skip_if_registered() -> anyhow::Result<()> {
+    reset_for_tests();
+    init(DefaultConfig::Client, InitOptions::default())?;
+
+    let mut options = InitOptions::default();
+    options.skip_if_registered = true;
+    options.logging_level = Some(Level::DEBUG);
+    init(DefaultConfig::Server, options)?;
+
+    let snapshot = config_snapshot().expect("config snapshot available");
+    assert_eq!(snapshot.mode, DefaultConfig::Client);
+    assert_eq!(snapshot.region, Region::China);
+    Ok(())
+}
+
+#[test]
+fn init_clears_registered_feature_caches() -> anyhow::Result<()> {
+    reset_for_tests();
+    let calendar = TradingCalendar::new(vec![NaiveDate::from_ymd_opt(2024, 1, 2).unwrap()]);
+    let provider = DefaultDataProvider::with_calendar(calendar);
+    let timestamp = Utc.from_utc_datetime(
+        &NaiveDate::from_ymd_opt(2024, 1, 2)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+    );
+    let key = FeatureKey::new("TEST", "close", timestamp);
+
+    let frame = df! { "close" => &[1.0_f64] }?;
+    provider.store_feature(key.clone(), frame)?;
+    assert!(provider.load_feature(&key)?.is_some());
+
+    init(DefaultConfig::Client, InitOptions::default())?;
+
+    assert!(provider.load_feature(&key)?.is_none());
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement a `config` module that mirrors qlib's global settings (regions, default modes, init options) and wires `qliber::init` into the public API and CLI
- register feature backends with a cache registry so `clear_mem_cache` semantics match Python and expose the new configuration surface in the README and task list
- add regression tests covering initialization defaults, skip-if-registered handling, and cache clearing behaviour

## Testing
- cargo fmt
- cargo clippy -- -D warnings
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e875ac196c832b942d8fae874266e1