### PR TITLE
Add Python fallback for rolling operators

### DIFF
--- a/qlib/data/ops.py
+++ b/qlib/data/ops.py
@@ -8,26 +8,96 @@ from __future__ import print_function
 import numpy as np
 import pandas as pd
 
-from typing import Union, List, Type
+from typing import Callable, Tuple, Union, List, Type
 from scipy.stats import percentileofscore
 from .base import Expression, ExpressionOps, Feature, PFeature
 from ..log import get_module_logger
 from ..utils import get_callable_kwargs
 
+
+def _linear_regression_statistics(window_values: np.ndarray) -> Tuple[float, float, float]:
+    """Compute slope, residual, and r-square for the provided window.
+
+    The helper emulates the Cython implementation by ignoring NaN values and
+    assigning sequential indices to the valid observations within the window.
+    """
+
+    mask = ~np.isnan(window_values)
+    valid = window_values[mask]
+    if valid.size == 0:
+        return np.nan, np.nan, np.nan
+
+    x = np.arange(1, valid.size + 1, dtype=float)
+    y = valid.astype(float)
+    x_mean = x.mean()
+    y_mean = y.mean()
+
+    x_dev = x - x_mean
+    y_dev = y - y_mean
+    cov = float(np.dot(x_dev, y_dev))
+    var_x = float(np.dot(x_dev, x_dev))
+    var_y = float(np.dot(y_dev, y_dev))
+
+    slope = cov / var_x if var_x > 0 else np.nan
+    intercept = y_mean - slope * x_mean if np.isfinite(slope) else np.nan
+    if var_x > 0 and var_y > 0:
+        r_square = (cov * cov) / (var_x * var_y)
+    else:
+        r_square = np.nan
+
+    if mask[-1] and np.isfinite(slope) and np.isfinite(intercept):
+        last_position = int(mask.cumsum()[-1])
+        residual = window_values[-1] - (slope * last_position + intercept)
+    else:
+        residual = np.nan
+
+    return slope, residual, r_square
+
+
+def _python_rolling_template(
+    values: np.ndarray, window: int, extractor: Callable[[float, float, float], float]
+) -> np.ndarray:
+    if window <= 0:
+        raise ValueError("window must be a positive integer")
+
+    array = np.asarray(values, dtype=float)
+    result = np.full(array.shape, np.nan, dtype=float)
+
+    for idx in range(array.shape[0]):
+        start = max(0, idx - window + 1)
+        window_values = array[start : idx + 1]
+        slope, residual, r_square = _linear_regression_statistics(window_values)
+        result[idx] = extractor(slope, residual, r_square)
+
+    return result
+
+
 try:
     from ._libs.rolling import rolling_slope, rolling_rsquare, rolling_resi
     from ._libs.expanding import expanding_slope, expanding_rsquare, expanding_resi
-except ImportError:
+except (ImportError, ValueError):
     print(
         "#### Do not import qlib package in the repository directory in case of importing qlib from . without compiling #####"
     )
-    raise
-except ValueError:
-    print("!!!!!!!! A error occurs when importing operators implemented based on Cython.!!!!!!!!")
-    print("!!!!!!!! They will be disabled. Please Upgrade your numpy to enable them     !!!!!!!!")
-    # We catch this error because some platform can't upgrade there package (e.g. Kaggle)
-    # https://www.kaggle.com/general/293387
-    # https://www.kaggle.com/product-feedback/98562
+    print("!!!!!!!! Fallback to Python implementations for rolling operators.!!!!!!!!")
+
+    def rolling_slope(a: np.ndarray, window: int) -> np.ndarray:
+        return _python_rolling_template(a, window, lambda slope, _resi, _r2: slope)
+
+    def rolling_rsquare(a: np.ndarray, window: int) -> np.ndarray:
+        return _python_rolling_template(a, window, lambda _slope, _resi, r2: r2)
+
+    def rolling_resi(a: np.ndarray, window: int) -> np.ndarray:
+        return _python_rolling_template(a, window, lambda _slope, resi, _r2: resi)
+
+    def expanding_slope(a: np.ndarray) -> np.ndarray:
+        return _python_rolling_template(a, a.shape[0], lambda slope, _resi, _r2: slope)
+
+    def expanding_rsquare(a: np.ndarray) -> np.ndarray:
+        return _python_rolling_template(a, a.shape[0], lambda _slope, _resi, r2: r2)
+
+    def expanding_resi(a: np.ndarray) -> np.ndarray:
+        return _python_rolling_template(a, a.shape[0], lambda _slope, resi, _r2: resi)
 
 
 np.seterr(invalid="ignore")

--- a/task.md
+++ b/task.md
@@ -1,0 +1,7 @@
+# Task List
+
+- [x] Survey repository structure and outstanding TODO markers.
+- [x] Identify failing tests caused by missing package path configuration.
+- [x] Update test configuration to ensure the qlib package is importable without installation.
+- [x] Re-run affected tests to confirm success.
+- [x] Summarize changes and testing results.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,15 @@
 import os
 import sys
+from pathlib import Path
 
 """Ignore RL tests on non-linux platform."""
 collect_ignore = []
+
+# Ensure the repository root is importable so ``import qlib`` works when tests
+# are executed from within the ``tests`` directory.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 if sys.platform != "linux":
     for root, dirs, files in os.walk("rl"):


### PR DESCRIPTION
## Summary
- add Python implementations of the rolling/expanding operators as a fallback when the compiled extensions are unavailable
- ensure the test suite can import the local qlib package by prepending the repository root to sys.path
- record the active tasks and their completion status in task.md

## Testing
- pytest tests/misc/test_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e91a73ddb8832bab9c4e9110fd38b1