### PR TITLE
feat(qliber): add smartcore xgboost trainer support

### DIFF
--- a/qliber/Cargo.lock
+++ b/qliber/Cargo.lock
@@ -1816,10 +1816,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1898,6 +1962,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2407,6 +2480,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "smartcore",
  "tempfile",
  "thiserror",
  "tracing",
@@ -2833,6 +2907,20 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smartcore"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e569eba50db04f51f83ad1ad2186cc1cf88bb68de052177bda165f6cdcf8d81"
+dependencies = [
+ "approx",
+ "cfg-if",
+ "num",
+ "num-traits",
+ "ordered-float",
+ "rand",
+]
 
 [[package]]
 name = "smartstring"

--- a/qliber/Cargo.toml
+++ b/qliber/Cargo.toml
@@ -24,6 +24,7 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "json", "env-filter", "time"] }
 reqwest = { version = "0.11", features = ["blocking", "json"], optional = false }
 llama_cpp = { version = "0.3.2", optional = true, default-features = false, features = ["compat"] }
+smartcore = { version = "0.4.5", default-features = false }
 
 [dev-dependencies]
 approx = "0.5"

--- a/qliber/README.md
+++ b/qliber/README.md
@@ -148,6 +148,33 @@ The `risk_analysis` and `indicator_analysis_with_method` helpers accept the same
 options as Qlib's Python API, making it straightforward to port workflows that rely on
 `mode="sum"/"product"` or indicator weighting strings without changing call sites.
 
+### Modeling
+
+`qliber::trainer` mirrors Qlib's model orchestration layer. Alongside the baseline
+`MeanModel`, the crate now provides an `XgBoostModel` built on SmartCore's gradient
+boosting implementation to cover the LightGBM-style scenarios documented in the Python
+stack. Both models expose the common `TrainableModel` trait so they can be dropped into
+existing trainer pipelines:
+
+```rust
+use polars::prelude::*;
+use qliber::{ExperimentManager, Trainer, XgBoostModel, XgBoostParameters};
+
+let features = DataFrame::new(vec![Series::new("feature", vec![1.0, 2.0, 3.0])])?;
+let labels = DataFrame::new(vec![Series::new("label", vec![3.0, 5.0, 7.0])])?;
+
+let manager = ExperimentManager::new();
+let recorder = manager.start("boosting-demo");
+let params = XgBoostParameters::default().with_n_estimators(50).with_max_depth(3);
+let mut model = XgBoostModel::new("label", vec!["feature".into()]).with_parameters(params);
+let mut trainer = Trainer::new(recorder, &mut model, "label", 1);
+trainer.train(&features, &labels)?;
+```
+
+`XgBoostParameters` re-exports SmartCore's builder so downstream applications can tune
+learning rate, tree depth, regularization, and sampling hyper-parameters without depending
+on SmartCore directly.
+
 ### Configuration
 
 `qliber::init` mirrors the behavior of `qlib.config` and `qlib.init` by providing global

--- a/qliber/docs/parity.md
+++ b/qliber/docs/parity.md
@@ -20,10 +20,11 @@ Python implementation (`qlib/`) and the Rust port (`qliber/`).
 
 1. **Model zoo parity** – The Python stack includes a wide collection of machine
    learning models (e.g., gradient boosting, meta-learning ensembles, and risk
-   models) under `qlib/model`. The Rust crate currently exposes a baseline
-   `MeanModel` to prove out the training pipeline and lacks equivalents for the
-   richer algorithms, particularly the ensemble operators and meta-learning
-   helpers defined in `qlib/model/ens` and `qlib/model/meta`.
+   models) under `qlib/model`. `qliber` now ships both the baseline `MeanModel`
+   and an `XgBoostModel` backed by SmartCore's gradient boosting implementation,
+   covering the LightGBM-style workflows. Remaining work focuses on ensemble
+   operators and meta-learning helpers defined in `qlib/model/ens` and
+   `qlib/model/meta`.
 2. **Advanced interpretation utilities** – Python provides interpretation and
    explainability helpers (`qlib/model/interpret`) that are not yet mirrored in
    Rust.
@@ -37,9 +38,7 @@ Python implementation (`qlib/`) and the Rust port (`qliber/`).
 
 ## Next steps
 
-- Port a representative gradient boosting model (e.g., LightGBM) to Rust or
-  integrate via FFI.
 - Recreate the ensemble/grouping abstractions for production parity with
   `qlib.model.ens`.
 - Extend the trainer module with plugin support mirroring the Python
-  configuration surface.
+  configuration surface and integrate external ML backends.

--- a/qliber/src/lib.rs
+++ b/qliber/src/lib.rs
@@ -58,7 +58,10 @@ pub use remote::{MockTransport, RemoteDataClient, RemoteError, RemoteResult, Rem
 pub use rl::{
     Agent, CounterEnvironment, Environment, IncrementAgent, RlError, RlResult, RlTrainer,
 };
-pub use trainer::{MeanModel, TrainableModel, Trainer, TrainingError, TrainingResult};
+pub use trainer::{
+    MeanModel, TrainableModel, Trainer, TrainingError, TrainingResult, XgBoostModel,
+    XgBoostObjective, XgBoostParameters,
+};
 pub use workflow::{
     ExperimentManager, ExperimentRecord, Recorder, TaskManager, WorkflowError, WorkflowResult,
 };

--- a/qliber/src/trainer.rs
+++ b/qliber/src/trainer.rs
@@ -1,8 +1,13 @@
 use polars::prelude::*;
+use smartcore::linalg::basic::matrix::DenseMatrix;
+use smartcore::xgboost::{XGRegressor, XGRegressorParameters};
 use thiserror::Error;
 
 use crate::logging::log_event;
 use crate::workflow::Recorder;
+
+pub use smartcore::xgboost::XGRegressorParameters as XgBoostParameters;
+pub use smartcore::xgboost::xgb_regressor::Objective as XgBoostObjective;
 
 #[derive(Debug, Error)]
 pub enum TrainingError {
@@ -59,6 +64,136 @@ impl TrainableModel for MeanModel {
         let rows = features.height();
         let predictions = Float64Chunked::full("prediction", self.mean, rows).into_series();
         Ok(DataFrame::new(vec![predictions])?)
+    }
+}
+
+type SmartcoreRegressor = XGRegressor<f64, f64, DenseMatrix<f64>, Vec<f64>>;
+
+pub struct XgBoostModel {
+    label_column: String,
+    feature_columns: Vec<String>,
+    parameters: XGRegressorParameters,
+    model: Option<SmartcoreRegressor>,
+}
+
+impl std::fmt::Debug for XgBoostModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("XgBoostModel")
+            .field("label_column", &self.label_column)
+            .field("feature_columns", &self.feature_columns)
+            .field("parameters", &self.parameters)
+            .field("is_trained", &self.model.is_some())
+            .finish()
+    }
+}
+
+impl XgBoostModel {
+    pub fn new(label_column: impl Into<String>, feature_columns: impl Into<Vec<String>>) -> Self {
+        Self {
+            label_column: label_column.into(),
+            feature_columns: feature_columns.into(),
+            parameters: XGRegressorParameters::default(),
+            model: None,
+        }
+    }
+
+    pub fn with_parameters(mut self, parameters: XGRegressorParameters) -> Self {
+        self.parameters = parameters;
+        self
+    }
+
+    pub fn set_parameters(&mut self, parameters: XGRegressorParameters) {
+        self.parameters = parameters;
+    }
+
+    fn feature_matrix(&self, features: &DataFrame) -> TrainingResult<DenseMatrix<f64>> {
+        if self.feature_columns.is_empty() {
+            return Err(TrainingError::Model(
+                "no feature columns configured for XgBoostModel".into(),
+            ));
+        }
+
+        let mut columns = Vec::with_capacity(self.feature_columns.len());
+        for name in &self.feature_columns {
+            let series = features
+                .column(name)
+                .map_err(|err| TrainingError::Model(err.to_string()))?;
+            let chunked = series
+                .f64()
+                .map_err(|_| TrainingError::Model(format!("feature column '{name}' must be f64")))?
+                .clone();
+            columns.push((name, chunked));
+        }
+
+        let row_count = features.height();
+        let mut data = Vec::with_capacity(row_count);
+        for row_idx in 0..row_count {
+            let mut row = Vec::with_capacity(columns.len());
+            for (name, column) in &columns {
+                let value = column.get(row_idx).ok_or_else(|| {
+                    TrainingError::Model(format!(
+                        "null value encountered in feature column '{name}' at row {row_idx}"
+                    ))
+                })?;
+                row.push(value);
+            }
+            data.push(row);
+        }
+
+        DenseMatrix::from_2d_vec(&data).map_err(|err| TrainingError::Model(err.to_string()))
+    }
+
+    fn label_vector(&self, labels: &DataFrame) -> TrainingResult<Vec<f64>> {
+        let series = labels
+            .column(&self.label_column)
+            .map_err(|err| TrainingError::Model(err.to_string()))?;
+        let chunked = series.f64().map_err(|_| {
+            TrainingError::Model(format!("label column '{}' must be f64", self.label_column))
+        })?;
+        let mut values = Vec::with_capacity(chunked.len());
+        for (idx, value) in chunked.into_iter().enumerate() {
+            let value = value.ok_or_else(|| {
+                TrainingError::Model(format!(
+                    "null value encountered in label column '{}' at row {idx}",
+                    self.label_column
+                ))
+            })?;
+            values.push(value);
+        }
+        Ok(values)
+    }
+}
+
+impl TrainableModel for XgBoostModel {
+    fn fit(&mut self, features: &DataFrame, labels: &DataFrame) -> TrainingResult<()> {
+        if features.height() != labels.height() {
+            return Err(TrainingError::Model(format!(
+                "feature rows ({}) do not match label rows ({})",
+                features.height(),
+                labels.height()
+            )));
+        }
+
+        let matrix = self.feature_matrix(features)?;
+        let target = self.label_vector(labels)?;
+
+        let model = XGRegressor::fit(&matrix, &target, self.parameters.clone())
+            .map_err(|err| TrainingError::Model(err.to_string()))?;
+        self.model = Some(model);
+        Ok(())
+    }
+
+    fn predict(&self, features: &DataFrame) -> TrainingResult<DataFrame> {
+        let model = self
+            .model
+            .as_ref()
+            .ok_or_else(|| TrainingError::Model("model is not fitted yet".into()))?;
+        let matrix = self.feature_matrix(features)?;
+        let predictions = model
+            .predict(&matrix)
+            .map_err(|err| TrainingError::Model(err.to_string()))?;
+        let series = Series::new("prediction", predictions);
+        Ok(DataFrame::new(vec![series])?)
     }
 }
 

--- a/qliber/task.md
+++ b/qliber/task.md
@@ -41,3 +41,6 @@
 - [x] Add Ollama HTTP client and GGUF inference support to mirror Python-side LLM helpers
 - [x] Provide a reproducible cargo build script for release builds
 - [x] Extend integration tests to cover the Ollama compatibility surface
+- [x] Integrate a gradient boosting model into qliber's trainer API to cover LightGBM-style parity
+- [ ] Extend the trainer registry with pluggable adapters for external ML frameworks
+- [ ] Port model interpretation utilities (`qlib/model/interpret`) into qliber

--- a/qliber/tests/trainer.rs
+++ b/qliber/tests/trainer.rs
@@ -1,0 +1,55 @@
+use polars::prelude::*;
+
+use qliber::{ExperimentManager, TrainableModel, Trainer, XgBoostModel, XgBoostParameters};
+
+#[test]
+fn xgboost_model_fits_linear_series() -> anyhow::Result<()> {
+    let feature_values: Vec<f64> = (0..100).map(|v| v as f64).collect();
+    let label_values: Vec<f64> = feature_values.iter().map(|v| 2.0 * v + 1.0).collect();
+
+    let features = DataFrame::new(vec![Series::new("feature", feature_values.clone())])?;
+    let labels = DataFrame::new(vec![Series::new("label", label_values.clone())])?;
+
+    let manager = ExperimentManager::new();
+    let recorder = manager.start("xgboost-linear");
+
+    let params = XgBoostParameters::default()
+        .with_n_estimators(200)
+        .with_learning_rate(0.1)
+        .with_max_depth(5)
+        .with_min_child_weight(1)
+        .with_lambda(1.0)
+        .with_gamma(0.0)
+        .with_subsample(1.0)
+        .with_seed(42);
+
+    let mut model = XgBoostModel::new("label", vec!["feature".to_string()]).with_parameters(params);
+    let mut trainer = Trainer::new(recorder.clone(), &mut model, "label", 1);
+    trainer.train(&features, &labels)?;
+    drop(trainer);
+
+    let predictions = model.predict(&features)?;
+    let predicted = predictions
+        .column("prediction")?
+        .f64()
+        .map_err(|_| anyhow::anyhow!("prediction column must be f64"))?;
+    let truth = labels
+        .column("label")?
+        .f64()
+        .map_err(|_| anyhow::anyhow!("label column must be f64"))?;
+
+    let mut mse = 0.0;
+    let mut count = 0.0;
+    for (pred, actual) in predicted.into_iter().zip(truth.into_iter()) {
+        let pred = pred.ok_or_else(|| anyhow::anyhow!("prediction contains null"))?;
+        let actual = actual.ok_or_else(|| anyhow::anyhow!("label contains null"))?;
+        let diff = pred - actual;
+        mse += diff * diff;
+        count += 1.0;
+    }
+    assert!(count > 0.0);
+    mse /= count;
+
+    assert!(mse < 1e-2, "mse was {mse}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- integrate a SmartCore-backed `XgBoostModel` into the trainer API and re-export the parameter/objective helpers
- document the new modeling capabilities, update the parity roadmap, and track follow-up trainer tasks
- add a regression test covering gradient boosting on linear data and wire up the SmartCore dependency

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ea5094bec0832b85ebcf983d11a8ac