### PR TITLE
Enhance qliber task manager queue semantics

### DIFF
--- a/qliber/README.md
+++ b/qliber/README.md
@@ -221,6 +221,53 @@ let importances = interpreter.feature_importance(&features, &labels)?;
 println!("Top feature: {} -> {:.4}", importances[0].feature, importances[0].importance);
 ```
 
+### Workflow task management
+
+The workflow module now mirrors Qlib's rolling task orchestration with a stateful
+`TaskManager`. Each queued task tracks its status, attempt count, and the last
+observed error, and failed tasks can be re-queued once the underlying issue is
+resolved:
+
+```rust
+use std::sync::{Arc, Mutex};
+
+use qliber::{
+    ExperimentManager, TaskManager, TaskStatus, WorkflowError,
+};
+
+let manager = ExperimentManager::new();
+let recorder = manager.start("workflow-demo");
+let tasks = TaskManager::new();
+
+let _ = tasks.enqueue("persist-metric", |recorder| {
+    recorder.log_metric("alpha", 0.1);
+    Ok(())
+});
+
+let toggle = Arc::new(Mutex::new(true));
+let flaky_gate = Arc::clone(&toggle);
+let flaky_id = tasks.enqueue("flaky", move |_recorder| {
+    let mut guard = flaky_gate.lock().expect("toggle");
+    if *guard {
+        *guard = false;
+        Err(WorkflowError::Io("transient network".into()))
+    } else {
+        Ok(())
+    }
+});
+
+tasks.run(&recorder);
+assert_eq!(tasks.by_status(TaskStatus::Failed).len(), 1);
+
+tasks.retry_failed();
+tasks.run(&recorder);
+
+let summary = tasks.get(flaky_id).expect("flaky task tracked");
+assert_eq!(summary.status, TaskStatus::Completed);
+assert_eq!(summary.attempts, 2);
+assert!(summary.last_error.is_some());
+```
+
 ### Ensembles and meta-learning
 
 The ensemble stack mirrors `qlib.model.ens` with support for learned blending

--- a/qliber/src/lib.rs
+++ b/qliber/src/lib.rs
@@ -75,7 +75,8 @@ pub use trainer::{
     XgBoostParameters,
 };
 pub use workflow::{
-    ExperimentManager, ExperimentRecord, Recorder, TaskManager, WorkflowError, WorkflowResult,
+    ExperimentManager, ExperimentRecord, Recorder, TaskManager, TaskStatus, TaskSummary,
+    WorkflowError, WorkflowResult,
 };
 
 pub type Result<T> = anyhow::Result<T>;

--- a/qliber/src/workflow.rs
+++ b/qliber/src/workflow.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde_json::Value;
 use thiserror::Error;
 
@@ -129,28 +129,304 @@ impl ExperimentManager {
     }
 }
 
-type TaskCallback = dyn Fn(&Recorder) + Send + Sync;
+type TaskFn = dyn Fn(&Recorder) -> WorkflowResult<()> + Send + Sync;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaskStatus {
+    Waiting,
+    Running,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskSummary {
+    pub id: u64,
+    pub name: String,
+    pub status: TaskStatus,
+    pub attempts: u32,
+    pub last_error: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+struct TaskEntry {
+    id: u64,
+    name: String,
+    status: TaskStatus,
+    attempts: u32,
+    last_error: Option<String>,
+    callback: Arc<TaskFn>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl TaskEntry {
+    fn new(id: u64, name: String, callback: Arc<TaskFn>) -> Self {
+        let now = Utc::now();
+        Self {
+            id,
+            name,
+            status: TaskStatus::Waiting,
+            attempts: 0,
+            last_error: None,
+            callback,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn summarize(&self) -> TaskSummary {
+        TaskSummary {
+            id: self.id,
+            name: self.name.clone(),
+            status: self.status,
+            attempts: self.attempts,
+            last_error: self.last_error.clone(),
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+        }
+    }
+}
 
 #[derive(Default)]
+struct TaskStore {
+    tasks: HashMap<u64, TaskEntry>,
+    queue: VecDeque<u64>,
+    next_id: u64,
+}
+
+#[derive(Clone, Default)]
 pub struct TaskManager {
-    tasks: Vec<Box<TaskCallback>>,
+    inner: Arc<Mutex<TaskStore>>,
 }
 
 impl TaskManager {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            inner: Arc::new(Mutex::new(TaskStore {
+                tasks: HashMap::new(),
+                queue: VecDeque::new(),
+                next_id: 1,
+            })),
+        }
     }
 
-    pub fn register<F>(&mut self, task: F)
+    fn enqueue_internal<F>(&self, name: Option<String>, task: F) -> u64
+    where
+        F: Fn(&Recorder) -> WorkflowResult<()> + Send + Sync + 'static,
+    {
+        let mut store = self.inner.lock().expect("lock task store");
+        let id = store.next_id;
+        store.next_id += 1;
+        let task_name = name.unwrap_or_else(|| format!("task-{id}"));
+        let entry = TaskEntry::new(id, task_name.clone(), Arc::new(task));
+        store.queue.push_back(id);
+        store.tasks.insert(id, entry);
+        drop(store);
+
+        log_event(
+            file!(),
+            "TaskManager",
+            "enqueue",
+            "workflow.task",
+            line!(),
+            &format!("Enqueued task `{task_name}` with id {id}"),
+            None,
+            "none",
+            "POST",
+        );
+
+        id
+    }
+
+    pub fn register<F>(&mut self, task: F) -> u64
     where
         F: Fn(&Recorder) + Send + Sync + 'static,
     {
-        self.tasks.push(Box::new(task));
+        let task_arc = move |recorder: &Recorder| {
+            task(recorder);
+            Ok(())
+        };
+        self.enqueue_internal(None, task_arc)
+    }
+
+    pub fn enqueue<F>(&self, name: impl Into<String>, task: F) -> u64
+    where
+        F: Fn(&Recorder) -> WorkflowResult<()> + Send + Sync + 'static,
+    {
+        self.enqueue_internal(Some(name.into()), task)
+    }
+
+    fn claim_next(&self) -> Option<(u64, Arc<TaskFn>, String)> {
+        let mut store = self.inner.lock().expect("lock task store");
+        let id = store.queue.pop_front()?;
+        if let Some(entry) = store.tasks.get_mut(&id) {
+            entry.status = TaskStatus::Running;
+            entry.attempts += 1;
+            entry.updated_at = Utc::now();
+            let name = entry.name.clone();
+            let callback = Arc::clone(&entry.callback);
+            drop(store);
+
+            log_event(
+                file!(),
+                "TaskManager",
+                "claim",
+                "workflow.task",
+                line!(),
+                &format!("Claimed task `{name}` (id {id}) for execution"),
+                None,
+                "none",
+                "GET",
+            );
+
+            Some((id, callback, name))
+        } else {
+            None
+        }
+    }
+
+    fn mark_completed(&self, id: u64, name: &str) {
+        if let Ok(mut store) = self.inner.lock() {
+            if let Some(entry) = store.tasks.get_mut(&id) {
+                entry.status = TaskStatus::Completed;
+                entry.updated_at = Utc::now();
+            }
+        }
+
+        log_event(
+            file!(),
+            "TaskManager",
+            "complete",
+            "workflow.task",
+            line!(),
+            &format!("Completed task `{name}` (id {id})"),
+            None,
+            "none",
+            "PUT",
+        );
+    }
+
+    fn mark_failed_internal(&self, id: u64, name: &str, error: String) {
+        if let Ok(mut store) = self.inner.lock() {
+            if let Some(entry) = store.tasks.get_mut(&id) {
+                entry.status = TaskStatus::Failed;
+                entry.last_error = Some(error.clone());
+                entry.updated_at = Utc::now();
+            }
+        }
+
+        log_event(
+            file!(),
+            "TaskManager",
+            "fail",
+            "workflow.task",
+            line!(),
+            &format!("Task `{name}` (id {id}) failed"),
+            Some(&error),
+            "none",
+            "PUT",
+        );
     }
 
     pub fn run(&self, recorder: &Recorder) {
-        for task in &self.tasks {
-            task(recorder);
+        while let Some((id, callback, name)) = self.claim_next() {
+            match callback(recorder) {
+                Ok(()) => self.mark_completed(id, &name),
+                Err(error) => self.mark_failed_internal(id, &name, error.to_string()),
+            }
         }
+    }
+
+    pub fn requeue(&self, id: u64) -> bool {
+        if let Ok(mut store) = self.inner.lock() {
+            let task_name = store.tasks.get_mut(&id).map(|entry| {
+                entry.status = TaskStatus::Waiting;
+                entry.updated_at = Utc::now();
+                entry.name.clone()
+            });
+
+            if let Some(name) = task_name {
+                store.queue.push_back(id);
+                drop(store);
+                log_event(
+                    file!(),
+                    "TaskManager",
+                    "requeue",
+                    "workflow.task",
+                    line!(),
+                    &format!("Requeued task `{name}` (id {id})"),
+                    None,
+                    "none",
+                    "POST",
+                );
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn retry_failed(&self) -> usize {
+        let mut requeued = Vec::new();
+        if let Ok(mut store) = self.inner.lock() {
+            for entry in store.tasks.values_mut() {
+                if entry.status == TaskStatus::Failed {
+                    entry.status = TaskStatus::Waiting;
+                    entry.updated_at = Utc::now();
+                    requeued.push((entry.id, entry.name.clone()));
+                }
+            }
+
+            for (id, _) in &requeued {
+                store.queue.push_back(*id);
+            }
+        }
+
+        for (id, name) in &requeued {
+            log_event(
+                file!(),
+                "TaskManager",
+                "retry_failed",
+                "workflow.task",
+                line!(),
+                &format!("Requeued failed task `{name}` (id {id})"),
+                None,
+                "none",
+                "POST",
+            );
+        }
+
+        requeued.len()
+    }
+
+    pub fn tasks(&self) -> Vec<TaskSummary> {
+        self.inner
+            .lock()
+            .expect("lock task store")
+            .tasks
+            .values()
+            .map(TaskEntry::summarize)
+            .collect()
+    }
+
+    pub fn by_status(&self, status: TaskStatus) -> Vec<TaskSummary> {
+        self.tasks()
+            .into_iter()
+            .filter(|task| task.status == status)
+            .collect()
+    }
+
+    pub fn get(&self, id: u64) -> Option<TaskSummary> {
+        self.inner
+            .lock()
+            .expect("lock task store")
+            .tasks
+            .get(&id)
+            .map(TaskEntry::summarize)
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.lock().expect("lock task store").tasks.len()
     }
 }

--- a/qliber/task.md
+++ b/qliber/task.md
@@ -48,3 +48,6 @@
 - [x] Implement factor risk model generation with shrinkage parity to `qlib.model.riskmodel`
 - [x] Rerun ensemble and risk model tests after port completion
 - [x] Run full `cargo test` to confirm overall stability post-port
+- [x] Expand workflow task management with queued status tracking and retries
+- [x] Add workflow tests covering task failure recovery and metadata retention
+- [x] Document the workflow task queue usage in the README

--- a/qliber/tests/workflow.rs
+++ b/qliber/tests/workflow.rs
@@ -1,15 +1,17 @@
 use polars::prelude::*;
 use serde_json::json;
 
-use qliber::workflow::{ExperimentManager, TaskManager};
-use qliber::{MeanModel, Trainer};
+use std::sync::{Arc, Mutex};
+
+use qliber::workflow::{ExperimentManager, TaskManager, TaskStatus};
+use qliber::{MeanModel, Trainer, WorkflowError};
 
 #[test]
 fn workflow_records_metrics() -> anyhow::Result<()> {
     let manager = ExperimentManager::new();
     let recorder = manager.start("test-experiment");
     let mut tasks = TaskManager::new();
-    tasks.register(|recorder| recorder.log_param("alpha", json!(0.1)));
+    let _ = tasks.register(|recorder| recorder.log_param("alpha", json!(0.1)));
     tasks.run(&recorder);
 
     let mut model = MeanModel::new("label");
@@ -22,4 +24,47 @@ fn workflow_records_metrics() -> anyhow::Result<()> {
     assert!(snapshot.metrics.contains_key("epoch_0_mse"));
     assert!(snapshot.parameters.contains_key("alpha"));
     Ok(())
+}
+
+#[test]
+fn task_manager_tracks_status_transitions() {
+    let manager = ExperimentManager::new();
+    let recorder = manager.start("task-tracker");
+    let tasks = TaskManager::new();
+
+    let _always_ok = tasks.enqueue("log", |recorder| {
+        recorder.log_metric("ok", 1.0);
+        Ok(())
+    });
+
+    let toggle = Arc::new(Mutex::new(true));
+    let toggle_task = Arc::clone(&toggle);
+    let fail_id = tasks.enqueue("flaky", move |_recorder| {
+        let mut flag = toggle_task.lock().expect("lock toggle");
+        if *flag {
+            *flag = false;
+            Err(WorkflowError::Io("transient".into()))
+        } else {
+            Ok(())
+        }
+    });
+
+    tasks.run(&recorder);
+
+    let summaries = tasks.tasks();
+    assert_eq!(summaries.len(), 2);
+    let failed = tasks.by_status(TaskStatus::Failed);
+    assert_eq!(failed.len(), 1);
+    assert_eq!(failed[0].id, fail_id);
+    assert_eq!(failed[0].attempts, 1);
+
+    let retried = tasks.retry_failed();
+    assert_eq!(retried, 1);
+
+    tasks.run(&recorder);
+
+    let flaky = tasks.get(fail_id).expect("flaky task recorded");
+    assert_eq!(flaky.status, TaskStatus::Completed);
+    assert_eq!(flaky.attempts, 2);
+    assert!(flaky.last_error.is_some());
 }

--- a/task.md
+++ b/task.md
@@ -21,3 +21,6 @@
 - [x] Extend Rust risk model tests to cover POET and structured estimators.
 - [x] Align structured PCA outputs with the Python reference implementation.
 - [x] Align structured factor analysis covariance with the Python reference implementation.
+- [x] Expand qliber workflow task management with queued status tracking and retries.
+- [x] Add regression tests covering TaskManager status transitions and retries.
+- [x] Document the enhanced TaskManager queue semantics in qliber's README.


### PR DESCRIPTION
## Summary
- extend qliber's workflow task manager with queued task metadata, structured logging, and retry utilities for failed runs
- add workflow regression coverage and documentation describing the new queue semantics, and re-export task status helpers
- record completion of the workflow task management work items in the project task lists

## Testing
- cargo test --manifest-path qliber/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68eaff37afbc832b98120c7960c9d9c9